### PR TITLE
use snake_case in table names

### DIFF
--- a/libs/db/schema.ts
+++ b/libs/db/schema.ts
@@ -1,17 +1,17 @@
 import { relations } from "drizzle-orm";
-import { pgSchema, serial, text, integer } from "drizzle-orm/pg-core";
+import { integer, pgSchema, text } from "drizzle-orm/pg-core";
 
 export const grumma = pgSchema("grumma");
 
-export const grammarPoints = grumma.table("GrammarPoint", {
+export const grammarPoints = grumma.table("grammar_point", {
 	id: integer("id").primaryKey(),
 	order: integer(),
 	structure: text(),
 	title: text().notNull().unique(),
 });
 
-export const exercises = grumma.table("Exercise", {
-	id: serial().primaryKey(),
+export const exercises = grumma.table("exercise", {
+	id: integer().primaryKey().generatedAlwaysAsIdentity(),
 	grammarPointId: integer()
 		.notNull()
 		.references(() => grammarPoints.id),


### PR DESCRIPTION
Looks like drizzle push works correctly with snake_case tables only. It's of course a mess and I will not adapt to the library's issues in the production later