### PR TITLE
replace contact us with community link

### DIFF
--- a/src/components/solid/HelpNav.tsx
+++ b/src/components/solid/HelpNav.tsx
@@ -11,6 +11,7 @@ import {
 import { NavButton } from "./NavButton";
 import { actions } from "astro:actions";
 import { toast } from "solid-toast";
+import { COMMUNITY_URL } from "~/libs/community";
 
 type Props = {
   onClick?: () => void;
@@ -43,8 +44,8 @@ const HelpMenu = (props: Props) => {
           <NavigationMenuLink href="/help" onClick={props.onClick}>
             <NavigationMenuLabel>How to use</NavigationMenuLabel>
           </NavigationMenuLink>
-          <NavigationMenuLink href="/contact-us" onClick={props.onClick}>
-            <NavigationMenuLabel>Contact us</NavigationMenuLabel>
+          <NavigationMenuLink href={COMMUNITY_URL} onClick={props.onClick}>
+            <NavigationMenuLabel>Community</NavigationMenuLabel>
           </NavigationMenuLink>
           <NavigationMenuLink
             href="/"
@@ -70,7 +71,11 @@ const HelpFlat = (props: Props) => {
   return (
     <div class="lg:hidden">
       <NavButton text="How to use" link="/help" onClick={props.onClick} />
-      <NavButton text="Contact us" link="/contact-us" onClick={props.onClick} />
+      <NavButton
+        text="Community"
+        link={COMMUNITY_URL}
+        onClick={props.onClick}
+      />
     </div>
   );
 };

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -14,6 +14,7 @@ import { Anchor } from "ui/anchor";
 import { isUserAdmin } from "libs/auth/admin";
 import { MdOutlinePrivacy_tip as PrivacyIcon } from "solid-icons/md";
 import { MdOutlineContact_support as SupportIcon } from "solid-icons/md";
+import { COMMUNITY_URL } from "~/libs/community";
 
 interface Props {
   title: string;
@@ -115,13 +116,9 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
         <Anchor href="/privacy-policy" class="text-black">
           <PrivacyIcon size={24} title="Privacy policy" />
         </Anchor>
-        {
-          loggedIn && (
-            <Anchor href="/contact-us" class="text-black">
-              <SupportIcon size={24} title="Contact us" />
-            </Anchor>
-          )
-        }
+        <Anchor href={COMMUNITY_URL} target="_blank" class="text-black">
+          <SupportIcon size={24} title="Community" />
+        </Anchor>
         <Toaster position="bottom-right" client:only="solid-js" />
       </footer>
     </main>

--- a/src/libs/community.ts
+++ b/src/libs/community.ts
@@ -1,0 +1,1 @@
+export const COMMUNITY_URL = "https://grumma.discourse.group/c/general/4";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced "Contact us" links with a new "Community" link in navigation and footer, providing direct access to the community forum.
  * Community link is now always visible to all users, regardless of login status.
  * Community link opens in a new tab for external access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->