### PR TITLE
admin: add hide gp checkbox

### DIFF
--- a/packages/ui/html-checkbox.tsx
+++ b/packages/ui/html-checkbox.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from "solid-js";
-import { createEffect, splitProps } from "solid-js";
+import { createEffect, createSignal, splitProps } from "solid-js";
 
 import { cn } from "ui/utils";
 
@@ -26,10 +26,17 @@ const HtmlCheckbox = (props: HtmlCheckboxProps) => {
     }
   });
 
+  const [checked, setChecked] = createSignal(!!props.checked);
+
+  // HACK: solid SSR
+  createEffect(() => {
+    setChecked(!!props.checked);
+  });
+
   return (
     <label
       class={cn(
-        "items-top group relative inline-flex space-x-2",
+        "items-top group relative inline-flex content-center items-center gap-2 space-x-2",
         local.disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
         local.class,
       )}
@@ -40,6 +47,7 @@ const HtmlCheckbox = (props: HtmlCheckboxProps) => {
         }}
         type="checkbox"
         class="peer sr-only"
+        checked={checked()}
         disabled={local.disabled}
         {...others}
       />
@@ -85,6 +93,7 @@ const HtmlCheckbox = (props: HtmlCheckboxProps) => {
           </svg>
         )}
       </span>
+      {props.children}
     </label>
   );
 };

--- a/src/actions/gp-management.ts
+++ b/src/actions/gp-management.ts
@@ -65,6 +65,7 @@ export const gpManagement = {
       detailedTitle: z.string().optional(),
       englishTitle: z.string().optional(),
       torfl: z.string().optional(),
+      hide: z.boolean(),
     }),
     handler: async (input, context) => {
       const result = await updateGrammarPoint(

--- a/src/features/grammar-point/GrammarPointForm.tsx
+++ b/src/features/grammar-point/GrammarPointForm.tsx
@@ -16,6 +16,7 @@ import {
 } from "packages/ui/select";
 import type { JSX } from "solid-js/jsx-runtime";
 import { ExplanationDisplay } from "@components/solid/grammar-point/ExplanationDisplay";
+import { HtmlCheckbox } from "ui/html-checkbox";
 
 interface GrammarPointFormProps {
   initialData?: {
@@ -27,6 +28,7 @@ interface GrammarPointFormProps {
     structure?: string;
     torfl?: string;
     explanation?: string;
+    hide?: boolean;
   };
   success?: boolean;
   error?: string;
@@ -52,6 +54,13 @@ export const GrammarPointForm = (props: GrammarPointFormProps) => {
         <CardTitle>Grammar Point</CardTitle>
       </CardHeader>
       <CardContent class="space-y-6">
+        <HtmlCheckbox
+          id="hide"
+          name="hide"
+          checked={props.initialData?.hide ?? true}
+        >
+          Hide from users (admins can still see it)
+        </HtmlCheckbox>
         <Show when={props.error}>
           <div class="rounded border border-red-200 bg-red-50 p-3 text-red-800 text-sm">
             {props.error}

--- a/src/pages/admin/grammar/[id]/index.astro
+++ b/src/pages/admin/grammar/[id]/index.astro
@@ -36,6 +36,7 @@ const updateResult = Astro.getActionResult(actions.updateGrammarPoint);
         englishTitle: grammarPoint.englishTitle ?? undefined,
         torfl: grammarPoint.torfl ?? undefined,
         explanation: grammarPoint.explanation ?? undefined,
+        hide: grammarPoint.hide ?? false,
       }}
     />
   </form>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Added a hide/visibility toggle for grammar points in the admin interface, allowing administrators to control whether individual grammar points are displayed or hidden throughout the system.

**UI/UX Improvements**
- Enhanced the checkbox control component with improved reactive state handling, better form field visibility, and refined visual styling for improved usability in admin forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->