### PR TITLE
add search grammar points for admin

### DIFF
--- a/src/features/grammar-point/GrammarPointForm.tsx
+++ b/src/features/grammar-point/GrammarPointForm.tsx
@@ -15,7 +15,6 @@ import { HtmlCheckbox } from "ui/html-checkbox";
 import type { Label } from "packages/grammar-sdk";
 import { Labels } from "./Labels";
 import { actions } from "astro:actions";
-import toast from "solid-toast";
 
 interface GrammarPointFormProps {
   initialData?: {

--- a/src/features/grammar-point/GrammarPointsTable.tsx
+++ b/src/features/grammar-point/GrammarPointsTable.tsx
@@ -1,4 +1,4 @@
-import { createMemo, createSignal, For } from "solid-js";
+import { createEffect, createSignal, For } from "solid-js";
 import { useDragAndDrop } from "@formkit/drag-and-drop/solid";
 import { Button } from "packages/ui/button";
 import { cn } from "packages/ui/utils";
@@ -8,22 +8,37 @@ import { SaveConfirmation } from "@components/common/SaveConfirmation";
 import type { GrammarPoint } from "packages/grammar-sdk";
 import type { Label } from "grammar-sdk";
 import { Badge } from "packages/ui/badge";
+import { TextField, TextFieldInput } from "packages/ui/text-field";
+import { searchGrammar } from "./search";
+import { IconButton } from "packages/ui/icon-button";
+import { Search } from "packages/ui/icons";
+import { GrammarPointWithLabels } from "./type";
 
 export const GrammarPointsTable = (props: {
   grammarPoints: GrammarPoint[];
   labels: Label[];
   error?: string;
 }) => {
-  const [parent, points, setPoints] = useDragAndDrop<
+  const grammarPoints = () =>
+    GrammarPointWithLabels(props.grammarPoints, props.labels);
+
+  const [rawSearch, setSearch] = createSignal("");
+  const search = () => rawSearch().toLowerCase().trim();
+  const sortEnabled = () => search() === "";
+
+  const [parent, rawPoints, setPoints, updateConfig] = useDragAndDrop<
     HTMLTableRowElement,
-    GrammarPoint
-  >(props.grammarPoints, {
+    GrammarPointWithLabels
+  >(grammarPoints(), {
     draggable: (el) => el.id !== "non-draggable",
   });
 
-  const labelsMap = createMemo(
-    () => new Map(props.labels.map((v) => [v.id, v])),
-  );
+  const points = () =>
+    search() ? searchGrammar(rawPoints(), search()) : rawPoints();
+
+  createEffect(() => {
+    updateConfig({ disabled: !sortEnabled() });
+  });
 
   if (props.error) {
     toast.error(props.error);
@@ -68,7 +83,7 @@ export const GrammarPointsTable = (props: {
     <div>
       <div class="flex flex-row justify-between">
         <h2 class="mb-4 font-semibold text-2xl">
-          Existing Grammar Points ({props.grammarPoints.length})
+          Existing Grammar Points ({grammarPoints().length})
         </h2>
         <SaveConfirmation title="grammar points order" onSave={updateOrder}>
           <Button
@@ -78,6 +93,29 @@ export const GrammarPointsTable = (props: {
           </Button>
         </SaveConfirmation>
       </div>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          const data = new FormData(e.currentTarget);
+          const search = data.get("search")?.toString() ?? "";
+          setSearch(search);
+        }}
+      >
+        <TextField
+          class="my-4 flex flex-row items-center gap-2"
+          onChange={(v) => !v.length && setSearch("")}
+        >
+          <TextFieldInput
+            name="search"
+            type="search"
+            placeholder="Search grammar points..."
+          />
+          <IconButton type="submit">
+            <Search />
+          </IconButton>
+        </TextField>
+      </form>
+
       <div class="overflow-hidden rounded-lg border border-slate-200 bg-white">
         <table class="w-full text-sm">
           <thead>
@@ -107,8 +145,11 @@ export const GrammarPointsTable = (props: {
           </thead>
           <tbody ref={parent}>
             <For each={points()}>
-              {(gp, order) => {
-                const differentOrder = () => gp.order !== order() + 1;
+              {(gp, index) => {
+                const order = () => (sortEnabled() ? index() : gp.order - 1);
+
+                const differentOrder = () =>
+                  sortEnabled() && gp.order !== order() + 1;
                 return (
                   <tr
                     class="cursor-grab border-b transition hover:bg-slate-50 active:cursor-grabbing"
@@ -137,11 +178,7 @@ export const GrammarPointsTable = (props: {
                       )}
                     </td>
                     <td class="flex max-w-xs flex-row flex-wrap gap-1 px-6 py-3">
-                      <For
-                        each={gp.labels.map((labelId) =>
-                          labelsMap().get(labelId),
-                        )}
-                      >
+                      <For each={gp.labels}>
                         {(label) => {
                           if (!label) return null;
                           return (
@@ -226,7 +263,7 @@ export const GrammarPointsTable = (props: {
           </tfoot>
         </table>
 
-        {props.grammarPoints.length === 0 && (
+        {!grammarPoints().length && (
           <div class="px-6 py-12 text-center text-slate-500">
             <p>No grammar points yet. Create one using the form above!</p>
           </div>

--- a/src/features/grammar-point/GrammarPointsTable.tsx
+++ b/src/features/grammar-point/GrammarPointsTable.tsx
@@ -87,7 +87,10 @@ export const GrammarPointsTable = (props: {
         </h2>
         <SaveConfirmation title="grammar points order" onSave={updateOrder}>
           <Button
-            disabled={!points().some((gp, index) => gp.order !== index + 1)}
+            disabled={
+              !sortEnabled() ||
+              !points().some((gp, index) => gp.order !== index + 1)
+            }
           >
             Save Order
           </Button>

--- a/src/features/grammar-point/search.ts
+++ b/src/features/grammar-point/search.ts
@@ -1,0 +1,92 @@
+import type { GrammarPointWithLabels } from "./type";
+
+export const searchGrammar = (
+  grammarPoints: GrammarPointWithLabels[],
+  query: string,
+) => {
+  const strategies = buildStrategiesFrom(query);
+  return strategies.reduce(
+    (result, strategy) => strategy.apply(result),
+    grammarPoints,
+  );
+};
+
+type SearchStrategy = {
+  apply: (grammar: GrammarPointWithLabels[]) => GrammarPointWithLabels[];
+};
+
+type Keyword = "order" | "short" | "detailed" | "english" | "torfl" | "label";
+const keywords: Keyword[] = [
+  "order",
+  "short",
+  "detailed",
+  "english",
+  "torfl",
+  "label",
+];
+type KeywordQuery = `${Keyword}:${string}`;
+
+const isKeywordQuery = (query: string): query is KeywordQuery => {
+  return keywords.some((keyword) =>
+    query.toLowerCase().startsWith(`${keyword}:`),
+  );
+};
+
+// TODO: add support for "and" / "or" and search with quotes to include spaces, e.g. label:"no description"
+const buildStrategiesFrom = (query: string): SearchStrategy[] => {
+  const processedQuery = query.trim().toLowerCase().replaceAll(/\s+/g, " ");
+  const splitted = processedQuery.split(" ");
+  const plainTextQueries = splitted.filter((part) => !isKeywordQuery(part));
+  const keywordQueries = splitted.filter(isKeywordQuery);
+
+  const plainStrategies = plainTextQueries.map(PlainTextQuery);
+  const keywordStrategies = keywordQueries.map(KeywordBasedQuery);
+
+  return [...plainStrategies, ...keywordStrategies];
+};
+
+const PlainTextQuery: (query: string) => SearchStrategy = (query) => ({
+  apply: (grammar: GrammarPointWithLabels[]) =>
+    grammar.filter((gp) => {
+      return (
+        gp.order.toString() === query ||
+        gp.shortTitle.toLowerCase().includes(query) ||
+        gp.detailedTitle?.toLowerCase().includes(query) ||
+        gp.englishTitle?.toLowerCase().includes(query) ||
+        gp.torfl?.toLowerCase() === query ||
+        gp.labels.some((label) => label.name.toLowerCase().includes(query))
+      );
+    }),
+});
+
+const KeywordBasedQuery: (query: KeywordQuery) => SearchStrategy = (query) => ({
+  apply: (grammar: GrammarPointWithLabels[]) => {
+    const [keyword, ...rest] = query.split(":");
+    const value = rest.join(":"); // In case the value contains ":"
+
+    switch (keyword) {
+      case "order":
+        return grammar.filter((gp) => gp.order.toString() === value);
+      case "short":
+        return grammar.filter((gp) =>
+          gp.shortTitle.toLowerCase().includes(value),
+        );
+      case "detailed":
+        return grammar.filter((gp) =>
+          gp.detailedTitle?.toLowerCase().includes(value),
+        );
+      case "english":
+        return grammar.filter((gp) =>
+          gp.englishTitle?.toLowerCase().includes(value),
+        );
+      case "torfl":
+        return grammar.filter((gp) => gp.torfl?.toLowerCase() === value);
+      case "label":
+        return grammar.filter((gp) =>
+          gp.labels.some((label) => label.name.toLowerCase().includes(value)),
+        );
+      default:
+        return grammar; // If the keyword is not recognized, return the original list
+    }
+  },
+});

--- a/src/features/grammar-point/type.ts
+++ b/src/features/grammar-point/type.ts
@@ -1,0 +1,17 @@
+import type { GrammarPoint, Label } from "packages/grammar-sdk";
+
+export type GrammarPointWithLabels = Omit<GrammarPoint, "labels"> & {
+  labels: Label[];
+};
+export const GrammarPointWithLabels = (
+  grammarPoints: GrammarPoint[],
+  labels: Label[],
+) => {
+  const labelsMap = new Map(labels.map((v) => [v.id, v]));
+  return grammarPoints.map((gp) => ({
+    ...gp,
+    labels: gp.labels
+      .map((labelId) => labelsMap.get(labelId))
+      .filter((label): label is Label => !!label),
+  }));
+};


### PR DESCRIPTION
closes #244 
closes #224 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added advanced, keyword-capable grammar-point search (supports order, label, torfl, etc.).

* **Improvements**
  * Search now uses a dedicated form flow and clears appropriately.
  * Drag-and-drop sorting is disabled while searching to avoid conflicts.
  * Grammar points now show enriched label information for clearer display.

* **Chores**
  * Removed an unused import and cleaned up related internal code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->