### PR TITLE
add notifications read schema and migration

### DIFF
--- a/drizzle/0024_pale_liz_osborn.sql
+++ b/drizzle/0024_pale_liz_osborn.sql
@@ -1,0 +1,8 @@
+CREATE TYPE "grumma"."notificationSource" AS ENUM('community');--> statement-breakpoint
+CREATE TABLE "grumma"."notifications_read" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "grumma"."notifications_read_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"userId" text NOT NULL,
+	"notificationId" text NOT NULL,
+	"source" "grumma"."notificationSource" NOT NULL,
+	"readAt" timestamp NOT NULL
+);

--- a/drizzle/0025_simple_the_professor.sql
+++ b/drizzle/0025_simple_the_professor.sql
@@ -1,0 +1,2 @@
+CREATE INDEX "notifications_read_userId_index" ON "grumma"."notifications_read" USING btree ("userId");--> statement-breakpoint
+ALTER TABLE "grumma"."notifications_read" ADD CONSTRAINT "notifications_read_userId_notificationId_source_unique" UNIQUE("userId","notificationId","source");

--- a/drizzle/meta/0024_snapshot.json
+++ b/drizzle/meta/0024_snapshot.json
@@ -1,0 +1,992 @@
+{
+  "id": "ea96f031-7774-4d2d-832b-24969674604a",
+  "prevId": "ad11c3e9-c73c-4759-ab75-0c2d88da1d84",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "grumma.exercise": {
+      "name": "exercise",
+      "schema": "grumma",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "exercise_id_seq",
+            "schema": "grumma",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "grammarPointId": {
+          "name": "grammarPointId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ru": {
+          "name": "ru",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "en": {
+          "name": "en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "helper": {
+          "name": "helper",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "exercise_grammarPointId_grammar_point_id_fk": {
+          "name": "exercise_grammarPointId_grammar_point_id_fk",
+          "tableFrom": "exercise",
+          "tableTo": "grammar_point",
+          "schemaTo": "grumma",
+          "columnsFrom": [
+            "grammarPointId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "grumma.feedback": {
+      "name": "feedback",
+      "schema": "grumma",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "feedback_id_seq",
+            "schema": "grumma",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grammarPointId": {
+          "name": "grammarPointId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exerciseOrder": {
+          "name": "exerciseOrder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_grammarPointId_grammar_point_tmp_id_fk": {
+          "name": "feedback_grammarPointId_grammar_point_tmp_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "grammar_point_tmp",
+          "schemaTo": "tmp",
+          "columnsFrom": [
+            "grammarPointId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "grumma.grammar_point": {
+      "name": "grammar_point",
+      "schema": "grumma",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "shortTitle": {
+          "name": "shortTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "structure": {
+          "name": "structure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detailedTitle": {
+          "name": "detailedTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "englishTitle": {
+          "name": "englishTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "torfl": {
+          "name": "torfl",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grammar_point_shortTitle_unique": {
+          "name": "grammar_point_shortTitle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "shortTitle"
+          ]
+        },
+        "grammar_point_title_unique": {
+          "name": "grammar_point_title_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "title"
+          ]
+        },
+        "grammar_point_detailedTitle_unique": {
+          "name": "grammar_point_detailedTitle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "detailedTitle"
+          ]
+        },
+        "grammar_point_englishTitle_unique": {
+          "name": "grammar_point_englishTitle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "englishTitle"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "grumma.notifications_read": {
+      "name": "notifications_read",
+      "schema": "grumma",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "notifications_read_id_seq",
+            "schema": "grumma",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notificationId": {
+          "name": "notificationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "notificationSource",
+          "typeSchema": "grumma",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "grumma.space_repetition": {
+      "name": "space_repetition",
+      "schema": "grumma",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "space_repetition_id_seq",
+            "schema": "grumma",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answeredAt": {
+          "name": "answeredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grammarPointId": {
+          "name": "grammarPointId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isCorrect": {
+          "name": "isCorrect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewSessionId": {
+          "name": "reviewSessionId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "space_repetition_grammarPointId_grammar_point_tmp_id_fk": {
+          "name": "space_repetition_grammarPointId_grammar_point_tmp_id_fk",
+          "tableFrom": "space_repetition",
+          "tableTo": "grammar_point_tmp",
+          "schemaTo": "tmp",
+          "columnsFrom": [
+            "grammarPointId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "grumma.tour": {
+      "name": "tour",
+      "schema": "grumma",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tour_id_seq",
+            "schema": "grumma",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "tmp.acceptable_answer": {
+      "name": "acceptable_answer",
+      "schema": "tmp",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "acceptable_answer_id_seq",
+            "schema": "tmp",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "answerId": {
+          "name": "answerId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "acceptableAnswerVariant",
+          "typeSchema": "tmp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "acceptable_answer_answerId_exercise_part_id_fk": {
+          "name": "acceptable_answer_answerId_exercise_part_id_fk",
+          "tableFrom": "acceptable_answer",
+          "tableTo": "exercise_part",
+          "schemaTo": "tmp",
+          "columnsFrom": [
+            "answerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "tmp.exercise_part": {
+      "name": "exercise_part",
+      "schema": "tmp",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "exercise_part_id_seq",
+            "schema": "tmp",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "exerciseId": {
+          "name": "exerciseId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "exercisePartType",
+          "typeSchema": "tmp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ru'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "exercise_part_exerciseId_exercise_tmp_id_fk": {
+          "name": "exercise_part_exerciseId_exercise_tmp_id_fk",
+          "tableFrom": "exercise_part",
+          "tableTo": "exercise_tmp",
+          "schemaTo": "tmp",
+          "columnsFrom": [
+            "exerciseId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "tmp.exercise_tmp": {
+      "name": "exercise_tmp",
+      "schema": "tmp",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "exercise_tmp_id_seq",
+            "schema": "tmp",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "grammarPointId": {
+          "name": "grammarPointId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hide": {
+          "name": "hide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "exercise_tmp_grammarPointId_grammar_point_tmp_id_fk": {
+          "name": "exercise_tmp_grammarPointId_grammar_point_tmp_id_fk",
+          "tableFrom": "exercise_tmp",
+          "tableTo": "grammar_point_tmp",
+          "schemaTo": "tmp",
+          "columnsFrom": [
+            "grammarPointId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "exercise_tmp_grammarPointId_order_unique": {
+          "name": "exercise_tmp_grammarPointId_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "grammarPointId",
+            "order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "tmp.grammar_point_tmp": {
+      "name": "grammar_point_tmp",
+      "schema": "tmp",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "grammar_point_tmp_id_seq",
+            "schema": "tmp",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "shortTitle": {
+          "name": "shortTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detailedTitle": {
+          "name": "detailedTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "englishTitle": {
+          "name": "englishTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "structure": {
+          "name": "structure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "torfl": {
+          "name": "torfl",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hide": {
+          "name": "hide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grammar_point_tmp_shortTitle_unique": {
+          "name": "grammar_point_tmp_shortTitle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "shortTitle"
+          ]
+        },
+        "grammar_point_tmp_order_unique": {
+          "name": "grammar_point_tmp_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "tmp.label": {
+      "name": "label",
+      "schema": "tmp",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "label_id_seq",
+            "schema": "tmp",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "label_name_unique": {
+          "name": "label_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "tmp.label_to_grammar_point": {
+      "name": "label_to_grammar_point",
+      "schema": "tmp",
+      "columns": {
+        "labelId": {
+          "name": "labelId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grammarPointId": {
+          "name": "grammarPointId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "label_to_grammar_point_labelId_label_id_fk": {
+          "name": "label_to_grammar_point_labelId_label_id_fk",
+          "tableFrom": "label_to_grammar_point",
+          "tableTo": "label",
+          "schemaTo": "tmp",
+          "columnsFrom": [
+            "labelId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "label_to_grammar_point_grammarPointId_grammar_point_tmp_id_fk": {
+          "name": "label_to_grammar_point_grammarPointId_grammar_point_tmp_id_fk",
+          "tableFrom": "label_to_grammar_point",
+          "tableTo": "grammar_point_tmp",
+          "schemaTo": "tmp",
+          "columnsFrom": [
+            "grammarPointId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "label_to_grammar_point_labelId_grammarPointId_pk": {
+          "name": "label_to_grammar_point_labelId_grammarPointId_pk",
+          "columns": [
+            "labelId",
+            "grammarPointId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "grumma.notificationSource": {
+      "name": "notificationSource",
+      "schema": "grumma",
+      "values": [
+        "community"
+      ]
+    },
+    "tmp.exercisePartType": {
+      "name": "exercisePartType",
+      "schema": "tmp",
+      "values": [
+        "text",
+        "answer"
+      ]
+    },
+    "tmp.acceptableAnswerVariant": {
+      "name": "acceptableAnswerVariant",
+      "schema": "tmp",
+      "values": [
+        "correct",
+        "incorrect",
+        "try-again"
+      ]
+    }
+  },
+  "schemas": {
+    "grumma": "grumma",
+    "tmp": "tmp"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0025_snapshot.json
+++ b/drizzle/meta/0025_snapshot.json
@@ -1,0 +1,1018 @@
+{
+  "id": "14f57027-e091-424e-b1f8-94cff8359e85",
+  "prevId": "ea96f031-7774-4d2d-832b-24969674604a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "grumma.exercise": {
+      "name": "exercise",
+      "schema": "grumma",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "exercise_id_seq",
+            "schema": "grumma",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "grammarPointId": {
+          "name": "grammarPointId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ru": {
+          "name": "ru",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "en": {
+          "name": "en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "helper": {
+          "name": "helper",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "exercise_grammarPointId_grammar_point_id_fk": {
+          "name": "exercise_grammarPointId_grammar_point_id_fk",
+          "tableFrom": "exercise",
+          "tableTo": "grammar_point",
+          "schemaTo": "grumma",
+          "columnsFrom": [
+            "grammarPointId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "grumma.feedback": {
+      "name": "feedback",
+      "schema": "grumma",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "feedback_id_seq",
+            "schema": "grumma",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grammarPointId": {
+          "name": "grammarPointId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exerciseOrder": {
+          "name": "exerciseOrder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_grammarPointId_grammar_point_tmp_id_fk": {
+          "name": "feedback_grammarPointId_grammar_point_tmp_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "grammar_point_tmp",
+          "schemaTo": "tmp",
+          "columnsFrom": [
+            "grammarPointId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "grumma.grammar_point": {
+      "name": "grammar_point",
+      "schema": "grumma",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "shortTitle": {
+          "name": "shortTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "structure": {
+          "name": "structure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detailedTitle": {
+          "name": "detailedTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "englishTitle": {
+          "name": "englishTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "torfl": {
+          "name": "torfl",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grammar_point_shortTitle_unique": {
+          "name": "grammar_point_shortTitle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "shortTitle"
+          ]
+        },
+        "grammar_point_title_unique": {
+          "name": "grammar_point_title_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "title"
+          ]
+        },
+        "grammar_point_detailedTitle_unique": {
+          "name": "grammar_point_detailedTitle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "detailedTitle"
+          ]
+        },
+        "grammar_point_englishTitle_unique": {
+          "name": "grammar_point_englishTitle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "englishTitle"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "grumma.notifications_read": {
+      "name": "notifications_read",
+      "schema": "grumma",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "notifications_read_id_seq",
+            "schema": "grumma",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notificationId": {
+          "name": "notificationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "notificationSource",
+          "typeSchema": "grumma",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "notifications_read_userId_index": {
+          "name": "notifications_read_userId_index",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notifications_read_userId_notificationId_source_unique": {
+          "name": "notifications_read_userId_notificationId_source_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId",
+            "notificationId",
+            "source"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "grumma.space_repetition": {
+      "name": "space_repetition",
+      "schema": "grumma",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "space_repetition_id_seq",
+            "schema": "grumma",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answeredAt": {
+          "name": "answeredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grammarPointId": {
+          "name": "grammarPointId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isCorrect": {
+          "name": "isCorrect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewSessionId": {
+          "name": "reviewSessionId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "space_repetition_grammarPointId_grammar_point_tmp_id_fk": {
+          "name": "space_repetition_grammarPointId_grammar_point_tmp_id_fk",
+          "tableFrom": "space_repetition",
+          "tableTo": "grammar_point_tmp",
+          "schemaTo": "tmp",
+          "columnsFrom": [
+            "grammarPointId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "grumma.tour": {
+      "name": "tour",
+      "schema": "grumma",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tour_id_seq",
+            "schema": "grumma",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "tmp.acceptable_answer": {
+      "name": "acceptable_answer",
+      "schema": "tmp",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "acceptable_answer_id_seq",
+            "schema": "tmp",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "answerId": {
+          "name": "answerId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "acceptableAnswerVariant",
+          "typeSchema": "tmp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "acceptable_answer_answerId_exercise_part_id_fk": {
+          "name": "acceptable_answer_answerId_exercise_part_id_fk",
+          "tableFrom": "acceptable_answer",
+          "tableTo": "exercise_part",
+          "schemaTo": "tmp",
+          "columnsFrom": [
+            "answerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "tmp.exercise_part": {
+      "name": "exercise_part",
+      "schema": "tmp",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "exercise_part_id_seq",
+            "schema": "tmp",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "exerciseId": {
+          "name": "exerciseId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "exercisePartType",
+          "typeSchema": "tmp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ru'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "exercise_part_exerciseId_exercise_tmp_id_fk": {
+          "name": "exercise_part_exerciseId_exercise_tmp_id_fk",
+          "tableFrom": "exercise_part",
+          "tableTo": "exercise_tmp",
+          "schemaTo": "tmp",
+          "columnsFrom": [
+            "exerciseId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "tmp.exercise_tmp": {
+      "name": "exercise_tmp",
+      "schema": "tmp",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "exercise_tmp_id_seq",
+            "schema": "tmp",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "grammarPointId": {
+          "name": "grammarPointId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hide": {
+          "name": "hide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "exercise_tmp_grammarPointId_grammar_point_tmp_id_fk": {
+          "name": "exercise_tmp_grammarPointId_grammar_point_tmp_id_fk",
+          "tableFrom": "exercise_tmp",
+          "tableTo": "grammar_point_tmp",
+          "schemaTo": "tmp",
+          "columnsFrom": [
+            "grammarPointId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "exercise_tmp_grammarPointId_order_unique": {
+          "name": "exercise_tmp_grammarPointId_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "grammarPointId",
+            "order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "tmp.grammar_point_tmp": {
+      "name": "grammar_point_tmp",
+      "schema": "tmp",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "grammar_point_tmp_id_seq",
+            "schema": "tmp",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "shortTitle": {
+          "name": "shortTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detailedTitle": {
+          "name": "detailedTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "englishTitle": {
+          "name": "englishTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "structure": {
+          "name": "structure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "torfl": {
+          "name": "torfl",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hide": {
+          "name": "hide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grammar_point_tmp_shortTitle_unique": {
+          "name": "grammar_point_tmp_shortTitle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "shortTitle"
+          ]
+        },
+        "grammar_point_tmp_order_unique": {
+          "name": "grammar_point_tmp_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "tmp.label": {
+      "name": "label",
+      "schema": "tmp",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "label_id_seq",
+            "schema": "tmp",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "label_name_unique": {
+          "name": "label_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "tmp.label_to_grammar_point": {
+      "name": "label_to_grammar_point",
+      "schema": "tmp",
+      "columns": {
+        "labelId": {
+          "name": "labelId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grammarPointId": {
+          "name": "grammarPointId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "label_to_grammar_point_labelId_label_id_fk": {
+          "name": "label_to_grammar_point_labelId_label_id_fk",
+          "tableFrom": "label_to_grammar_point",
+          "tableTo": "label",
+          "schemaTo": "tmp",
+          "columnsFrom": [
+            "labelId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "label_to_grammar_point_grammarPointId_grammar_point_tmp_id_fk": {
+          "name": "label_to_grammar_point_grammarPointId_grammar_point_tmp_id_fk",
+          "tableFrom": "label_to_grammar_point",
+          "tableTo": "grammar_point_tmp",
+          "schemaTo": "tmp",
+          "columnsFrom": [
+            "grammarPointId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "label_to_grammar_point_labelId_grammarPointId_pk": {
+          "name": "label_to_grammar_point_labelId_grammarPointId_pk",
+          "columns": [
+            "labelId",
+            "grammarPointId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "grumma.notificationSource": {
+      "name": "notificationSource",
+      "schema": "grumma",
+      "values": [
+        "community"
+      ]
+    },
+    "tmp.exercisePartType": {
+      "name": "exercisePartType",
+      "schema": "tmp",
+      "values": [
+        "text",
+        "answer"
+      ]
+    },
+    "tmp.acceptableAnswerVariant": {
+      "name": "acceptableAnswerVariant",
+      "schema": "tmp",
+      "values": [
+        "correct",
+        "incorrect",
+        "try-again"
+      ]
+    }
+  },
+  "schemas": {
+    "grumma": "grumma",
+    "tmp": "tmp"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1781176614088,
       "tag": "0023_swift_captain_stacy",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1781581771787,
+      "tag": "0024_pale_liz_osborn",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1781581771787,
       "tag": "0024_pale_liz_osborn",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1781602974623,
+      "tag": "0025_simple_the_professor",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/db/schema.ts
+++ b/libs/db/schema.ts
@@ -90,3 +90,15 @@ export const tour = grumma.table("tour", {
   type: text().notNull(),
   completed: boolean().notNull().default(false),
 });
+
+export const notificationSourceEnum = grumma.enum("notificationSource", [
+  "community",
+]);
+
+export const notificationsRead = grumma.table("notifications_read", {
+  id: integer().primaryKey().generatedAlwaysAsIdentity(),
+  userId: text().notNull(),
+  notificationId: text().notNull(),
+  source: notificationSourceEnum().notNull(),
+  readAt: timestamp().notNull(),
+});

--- a/libs/db/schema.ts
+++ b/libs/db/schema.ts
@@ -1,10 +1,12 @@
 import { relations } from "drizzle-orm";
 import {
   boolean,
+  index,
   integer,
   pgSchema,
   text,
   timestamp,
+  unique,
   uuid,
   varchar,
 } from "drizzle-orm/pg-core";
@@ -95,10 +97,17 @@ export const notificationSourceEnum = grumma.enum("notificationSource", [
   "community",
 ]);
 
-export const notificationsRead = grumma.table("notifications_read", {
-  id: integer().primaryKey().generatedAlwaysAsIdentity(),
-  userId: text().notNull(),
-  notificationId: text().notNull(),
-  source: notificationSourceEnum().notNull(),
-  readAt: timestamp().notNull(),
-});
+export const notificationsRead = grumma.table(
+  "notifications_read",
+  {
+    id: integer().primaryKey().generatedAlwaysAsIdentity(),
+    userId: text().notNull(),
+    notificationId: text().notNull(),
+    source: notificationSourceEnum().notNull(),
+    readAt: timestamp().notNull(),
+  },
+  (t) => [
+    unique().on(t.userId, t.notificationId, t.source),
+    index().on(t.userId),
+  ],
+);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tracking when notifications are read, enabling the system to record notification read events from community sources.
* **Database Updates**
  * Introduced a new data table to store notification read records.
  * Added indexing and a uniqueness rule to efficiently query and prevent duplicate read entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->