### PR TITLE
cache gp in memory to reduce Supabase consumption (I hope)

### DIFF
--- a/packages/grammar-sdk/src/grammar.ts
+++ b/packages/grammar-sdk/src/grammar.ts
@@ -1,4 +1,4 @@
-import type { Context } from "./context";
+import { Context } from "./context";
 import { getGrammarPoint, getGrammarPoints } from "./db";
 import { GrammarPoint, GrammarPoints } from "./grammar-point";
 
@@ -7,7 +7,7 @@ const cacheDuration = 1000 * 60 * 30; // 30 minutes
 let cacheTimestamp: number | null = null;
 
 const getFromCache = async (context: Context, ids?: string[]) => {
-  if (context.user.role === "admin") {
+  if (Context.isAdmin(context)) {
     return null;
   }
   if (
@@ -27,6 +27,11 @@ const getFromCache = async (context: Context, ids?: string[]) => {
 const setCache = (grammarPoints: GrammarPoint[]) => {
   InMemoryCache = grammarPoints;
   cacheTimestamp = Date.now();
+};
+
+export const clearCache = () => {
+  InMemoryCache = null;
+  cacheTimestamp = null;
 };
 
 export const fetchGrammarPoint = async (
@@ -59,6 +64,7 @@ export const fetchAllGrammarPoints = async (
   context: Context,
 ): Promise<GrammarPoint[]> => {
   const cached = await getFromCache(context);
+
   if (cached) {
     return GrammarPoints.filterVisible(cached, context);
   }

--- a/packages/grammar-sdk/src/grammar.ts
+++ b/packages/grammar-sdk/src/grammar.ts
@@ -2,10 +2,41 @@ import type { Context } from "./context";
 import { getGrammarPoint, getGrammarPoints } from "./db";
 import { GrammarPoint, GrammarPoints } from "./grammar-point";
 
+let InMemoryCache: GrammarPoint[] | null = null;
+const cacheDuration = 1000 * 60 * 30; // 30 minutes
+let cacheTimestamp: number | null = null;
+
+const getFromCache = async (context: Context, ids?: string[]) => {
+  if (context.user.role === "admin") {
+    return null;
+  }
+  if (
+    InMemoryCache &&
+    cacheTimestamp &&
+    Date.now() - cacheTimestamp < cacheDuration
+  ) {
+    if (ids) {
+      return InMemoryCache.filter((gp) => ids.includes(gp.id));
+    }
+    return InMemoryCache;
+  }
+  console.log("[GrammarPoints cache] Cache miss or expired");
+  return null;
+};
+
+const setCache = (grammarPoints: GrammarPoint[]) => {
+  InMemoryCache = grammarPoints;
+  cacheTimestamp = Date.now();
+};
+
 export const fetchGrammarPoint = async (
   id: string,
   context: Context,
 ): Promise<GrammarPoint | undefined> => {
+  const cached = await getFromCache(context, [id]);
+  if (cached?.at(0)) {
+    return GrammarPoint.filterVisible(cached[0], context);
+  }
   const maybeGrammarPoint = await getGrammarPoint(+id);
   return (
     maybeGrammarPoint && GrammarPoint.filterVisible(maybeGrammarPoint, context)
@@ -16,16 +47,24 @@ export const fetchGrammarPoints = async (
   ids: string[],
   context: Context,
 ): Promise<GrammarPoint[]> => {
-  return GrammarPoints.filterVisible(
-    await getGrammarPoints(ids.map((id) => +id)),
-    context,
-  );
+  const cached = await getFromCache(context, ids);
+  if (cached && cached.length === ids.length) {
+    return GrammarPoints.filterVisible(cached, context);
+  }
+  const grammarPoints = await getGrammarPoints(ids.map((id) => +id));
+  return GrammarPoints.filterVisible(grammarPoints, context);
 };
 
 export const fetchAllGrammarPoints = async (
   context: Context,
 ): Promise<GrammarPoint[]> => {
+  const cached = await getFromCache(context);
+  if (cached) {
+    return GrammarPoints.filterVisible(cached, context);
+  }
+
   const grammarPoints = await getGrammarPoints();
+  setCache(grammarPoints);
   return GrammarPoints.filterVisible(grammarPoints, context);
 };
 

--- a/src/pages/api/cache/index.astro
+++ b/src/pages/api/cache/index.astro
@@ -1,0 +1,30 @@
+---
+import type { APIRoute } from "astro";
+import { contextFromAstro } from "~/libs/context";
+import { clearCache, Context } from "packages/grammar-sdk";
+import logger from "libs/logger";
+
+export const GET: APIRoute = async (_context) => {
+  const isAdmin = Context.isAdmin(contextFromAstro(_context));
+  logger.info(`User is admin: ${isAdmin}`);
+
+  if (isAdmin) {
+    logger.info("Clearing cache...");
+    clearCache();
+  } else {
+    return new Response(JSON.stringify({ message: "Forbidden" }), {
+      status: 403,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+
+  return new Response(JSON.stringify({ message: "Cache cleared" }), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+};
+---


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added faster grammar-point loading with temporary in-memory caching.
  * Reuses recently fetched grammar data for single items, selected lists, and full lists when available.

* **Bug Fixes**
  * Improves consistency by only using cached list results when all requested items are present.
  * Ensures visibility rules still apply to cached grammar data based on the current context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->