### PR TITLE
split grammar points and exercises

### DIFF
--- a/libs/cache/tests/integration/index.test.ts
+++ b/libs/cache/tests/integration/index.test.ts
@@ -5,7 +5,7 @@ import {
   PostgreSqlContainer,
   type StartedPostgreSqlContainer,
 } from "@testcontainers/postgresql";
-import { execFileSync, execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import {
   afterAll,
   beforeAll,

--- a/libs/db/seed.ts
+++ b/libs/db/seed.ts
@@ -119,6 +119,7 @@ const exercisesData: (typeof exercisesTmp.$inferInsert)[] = Array.from(
     id: i + 1,
     grammarPointId: Math.floor(i / 4) + 1,
     order: i % 4,
+    hide: false,
   }),
 );
 

--- a/packages/grammar-sdk/__mocks__/index.ts
+++ b/packages/grammar-sdk/__mocks__/index.ts
@@ -11,11 +11,6 @@ export const mockGrammarPoint = (gp?: Partial<GrammarPoint>): GrammarPoint => ({
   englishTitle: `${faker.lorem.sentence()}`,
   order: faker.number.int({ min: 1, max: 100 }),
   structure: faker.string.sample(),
-  examples: [{ ru: mockExample(), en: mockExample(), order: 0, hide: false }],
-  exercises: Range(0, 12)
-    .map((i) => mockExercise({ grammarPointId: gp?.id, order: i }))
-    .toArray()
-    .toSorted((a, b) => a.order - b.order),
   torfl: "A1",
   hide: faker.datatype.boolean(),
   labels: faker.helpers.arrayElements(
@@ -47,3 +42,12 @@ export const mockExercise = (e?: Partial<Exercise>): Exercise => ({
   translationParts: [],
   ...e,
 });
+
+export const mockExercises = (
+  count: number,
+  grammarPointId?: string,
+): Exercise[] => {
+  return Range(0, count)
+    .map((i) => mockExercise({ grammarPointId, order: i }))
+    .toArray();
+};

--- a/packages/grammar-sdk/index.ts
+++ b/packages/grammar-sdk/index.ts
@@ -4,4 +4,5 @@ export * from "./src/label/type";
 export { type Exercise, exerciseSchema } from "./src/exercise";
 export * from "./src/context";
 export type { GrammarPoint } from "./src/grammar-point";
+export type { FullExample as Example } from "./src/example";
 export { AuthorizationError, isAuthorizationError } from "./src/db";

--- a/packages/grammar-sdk/src/db.ts
+++ b/packages/grammar-sdk/src/db.ts
@@ -52,7 +52,6 @@ export const getGrammarPoint = async (
 
 export const getGrammarPoints = async (
   ids?: number[],
-  include: { exercises?: boolean } = { exercises: true },
   dbClient: DbClient = db,
 ): Promise<GrammarPoint[]> => {
   const mainQuery = {
@@ -62,29 +61,6 @@ export const getGrammarPoints = async (
     },
   } as const;
 
-  const withExercises = {
-    exercises: {
-      with: {
-        parts: {
-          with: {
-            acceptableAnswers: true,
-          },
-        },
-      },
-    },
-  } as const;
-
-  if (include.exercises) {
-    const grammarDto = await dbClient.query.grammarPointsTmp.findMany({
-      ...mainQuery,
-      with: {
-        ...mainQuery.with,
-        ...withExercises,
-      },
-    });
-    return GrammarPointsDb.toGrammarPoints(grammarDto);
-  }
-
   const grammarDto = await dbClient.query.grammarPointsTmp.findMany(mainQuery);
 
   return GrammarPointsDb.toGrammarPoints(
@@ -93,6 +69,42 @@ export const getGrammarPoints = async (
       exercises: [],
     })),
   );
+};
+
+export const getExercisesByGrammarPointIds = async (
+  grammarPointIds: number[],
+  dbClient: DbClient = db,
+): Promise<Exercise[]> => {
+  const exercisesDto = await dbClient.query.exercisesTmp.findMany({
+    where: inArray(exercisesTmp.grammarPointId, grammarPointIds),
+    with: {
+      parts: {
+        with: {
+          acceptableAnswers: true,
+        },
+      },
+    },
+  });
+
+  return exercisesDto.map(ExerciseDb.toExercise);
+};
+
+export const getExercisesByGrammarPointId = async (
+  grammarPointId: number,
+  dbClient: DbClient = db,
+): Promise<Exercise[]> => {
+  const exercisesDto = await dbClient.query.exercisesTmp.findMany({
+    where: eq(exercisesTmp.grammarPointId, grammarPointId),
+    with: {
+      parts: {
+        with: {
+          acceptableAnswers: true,
+        },
+      },
+    },
+  });
+
+  return exercisesDto.map(ExerciseDb.toExercise);
 };
 
 export class AuthorizationError extends Error {
@@ -222,6 +234,7 @@ export const updateGrammarPoint = async (
     .where(eq(grammarPointsTmp.id, +id));
 
   if (updateData?.labels) {
+    // biome-ignore lint/style/noNonNullAssertion: <not null>
     return changeLabels(db, +id, updateData.labels!);
   }
 
@@ -364,14 +377,18 @@ export const putExercises = async (
     return err("Grammar point ID is required to create exercises.");
   }
 
-  const existingExercises = await getGrammarPoint(+grammarPointId, db).then(
-    (gp) => gp?.exercises,
-  );
-  if (!existingExercises) {
+  const gp = await getGrammarPoint(+grammarPointId, db);
+
+  if (!gp) {
     return err(
       `Grammar point ${grammarPointId} should exist before creating exercises. Please create the grammar point first.`,
     );
   }
+
+  const existingExercises = await getExercisesByGrammarPointId(
+    +grammarPointId,
+    db,
+  );
 
   const validation = Exercises.validate(exercises);
   if (validation.isErr()) {

--- a/packages/grammar-sdk/src/db.ts
+++ b/packages/grammar-sdk/src/db.ts
@@ -35,15 +35,6 @@ export const getGrammarPoint = async (
     where: eq(grammarPointsTmp.id, id),
     with: {
       labelsToGrammarPoints: { with: { label: true } },
-      exercises: {
-        with: {
-          parts: {
-            with: {
-              acceptableAnswers: true,
-            },
-          },
-        },
-      },
     },
   });
 
@@ -63,12 +54,7 @@ export const getGrammarPoints = async (
 
   const grammarDto = await dbClient.query.grammarPointsTmp.findMany(mainQuery);
 
-  return GrammarPointsDb.toGrammarPoints(
-    grammarDto.map((dto) => ({
-      ...dto,
-      exercises: [],
-    })),
-  );
+  return GrammarPointsDb.toGrammarPoints(grammarDto);
 };
 
 export const getExercisesByGrammarPointIds = async (

--- a/packages/grammar-sdk/src/example/index.ts
+++ b/packages/grammar-sdk/src/example/index.ts
@@ -1,5 +1,5 @@
 import type { Context } from "../context";
-import type { ExercisePart } from "../exercise";
+import type { Exercise, ExercisePart } from "../exercise";
 
 export type Example = [string, string, string];
 
@@ -33,12 +33,27 @@ export type FullExample = {
   hide: boolean;
 };
 
+const makeExample = (parts: ExercisePart[]) =>
+  parts
+    .toSorted((a, b) => a.index - b.index)
+    .map((p) => p.text)
+    .concat(new Array(3).fill(""))
+    .slice(0, 3) as [string, string, string];
+
 export const FullExample = {
   isVisible(example: FullExample, context: Context): boolean {
     if (example.hide) {
       return context.user.role === "admin";
     }
     return true;
+  },
+  fromExercise(exercise: Exercise): FullExample {
+    return {
+      ru: makeExample(exercise.parts),
+      en: makeExample(exercise.translationParts),
+      order: exercise.order,
+      hide: exercise.hide,
+    };
   },
 };
 
@@ -47,5 +62,8 @@ export const FullExamples = {
     return examples.filter((example) =>
       FullExample.isVisible(example, context),
     );
+  },
+  fromExercises(exercises: Exercise[]): FullExample[] {
+    return exercises.map((e) => FullExample.fromExercise(e));
   },
 };

--- a/packages/grammar-sdk/src/example/index.ts
+++ b/packages/grammar-sdk/src/example/index.ts
@@ -1,4 +1,4 @@
-import type { Context } from "../context";
+import { Context } from "../context";
 import type { Exercise, ExercisePart } from "../exercise";
 
 export type Example = [string, string, string];
@@ -43,7 +43,7 @@ const makeExample = (parts: ExercisePart[]) =>
 export const FullExample = {
   isVisible(example: FullExample, context: Context): boolean {
     if (example.hide) {
-      return context.user.role === "admin";
+      return Context.isAdmin(context);
     }
     return true;
   },

--- a/packages/grammar-sdk/src/exercise/index.ts
+++ b/packages/grammar-sdk/src/exercise/index.ts
@@ -66,6 +66,8 @@ export const Exercise = {
 
 export type UpdateExercise = Exercise & { id: number };
 
+export type ExercisesByGrammarPointId = Partial<Record<string, Exercise[]>>;
+
 export const Exercises = {
   filterVisible(exercises: Exercise[], context: Context) {
     return exercises.filter((ex) => Exercise.isVisible(ex, context));

--- a/packages/grammar-sdk/src/grammar-point/dto.ts
+++ b/packages/grammar-sdk/src/grammar-point/dto.ts
@@ -6,8 +6,6 @@ import type {
   grammarPointsTmp,
   labels,
 } from "../../../../libs/db/schema-tmp";
-import type { ExercisePart } from "../exercise";
-import { ExerciseDb } from "../exercise/dto";
 
 export type GrammarPointDb = typeof grammarPointsTmp.$inferSelect & {
   labelsToGrammarPoints: {
@@ -20,17 +18,8 @@ export type GrammarPointDb = typeof grammarPointsTmp.$inferSelect & {
   })[];
 };
 
-const makeExample = (parts: ExercisePart[]) =>
-  parts
-    .toSorted((a, b) => a.index - b.index)
-    .map((p) => p.text)
-    .concat(new Array(3).fill(""))
-    .slice(0, 3) as [string, string, string];
-
 export const GrammarPointDb = {
   toGrammarPoint: (g: GrammarPointDb): GrammarPoint => {
-    const exercises = g.exercises.map((e) => ExerciseDb.toExercise(e));
-
     return {
       id: `${g.id}`,
       shortTitle: g.shortTitle,
@@ -39,14 +28,7 @@ export const GrammarPointDb = {
       detailedTitle: g.detailedTitle ?? undefined,
       englishTitle: g.englishTitle ?? undefined,
       structure: g.structure ?? undefined,
-      examples: exercises.map((e) => ({
-        ru: makeExample(e.parts),
-        en: makeExample(e.translationParts),
-        order: e.order,
-        hide: e.hide,
-      })),
       explanation: g.explanation ?? undefined,
-      exercises,
       labels: g.labelsToGrammarPoints.map((l) => l.label.id),
       hide: g.hide,
     };

--- a/packages/grammar-sdk/src/grammar-point/dto.ts
+++ b/packages/grammar-sdk/src/grammar-point/dto.ts
@@ -1,21 +1,10 @@
 import type { GrammarPoint } from "../..";
-import type {
-  acceptableAnswersTmp,
-  exercisePartsTmp,
-  exercisesTmp,
-  grammarPointsTmp,
-  labels,
-} from "../../../../libs/db/schema-tmp";
+import type { grammarPointsTmp, labels } from "../../../../libs/db/schema-tmp";
 
 export type GrammarPointDb = typeof grammarPointsTmp.$inferSelect & {
   labelsToGrammarPoints: {
     label: typeof labels.$inferSelect;
   }[];
-  exercises: (typeof exercisesTmp.$inferSelect & {
-    parts: (typeof exercisePartsTmp.$inferSelect & {
-      acceptableAnswers?: (typeof acceptableAnswersTmp.$inferSelect)[];
-    })[];
-  })[];
 };
 
 export const GrammarPointDb = {

--- a/packages/grammar-sdk/src/grammar-point/index.test.ts
+++ b/packages/grammar-sdk/src/grammar-point/index.test.ts
@@ -1,8 +1,4 @@
-import {
-  mockExercise,
-  mockFullExample,
-  mockGrammarPoint,
-} from "../../__mocks__";
+import { mockGrammarPoint } from "../../__mocks__";
 import { GrammarPoints } from ".";
 import { describe, expect, test } from "vitest";
 
@@ -27,106 +23,6 @@ describe("GrammarPoint", () => {
       mockGrammarPoint({ order: 2, hide: true }),
       mockGrammarPoint({ order: 3, hide: false }),
       mockGrammarPoint({ order: 4, hide: true }),
-    ];
-
-    const result = GrammarPoints.filterVisible(grammarPoints, {
-      user: { role: "admin", id: "1" },
-    });
-    expect(result).toEqual(grammarPoints);
-  });
-
-  test("filters hidden exercises for non-admin", () => {
-    const grammarPoints = [
-      mockGrammarPoint({
-        order: 1,
-        hide: false,
-        exercises: [
-          mockExercise({ hide: false }),
-          mockExercise({ hide: false }),
-          mockExercise({ hide: true }),
-          mockExercise({ hide: false }),
-          mockExercise({ hide: true }),
-        ],
-      }),
-    ];
-
-    const result = GrammarPoints.filterVisible(grammarPoints, {
-      user: { role: "guest" },
-    });
-    expect(result).toEqual([
-      expect.objectContaining({
-        exercises: [
-          expect.objectContaining({ hide: false }),
-          expect.objectContaining({ hide: false }),
-          expect.objectContaining({ hide: false }),
-        ],
-      }),
-    ]);
-  });
-
-  test("does not filter hidden exercises for admin", () => {
-    const grammarPoints = [
-      mockGrammarPoint({
-        order: 1,
-        hide: false,
-        exercises: [
-          mockExercise({ hide: false }),
-          mockExercise({ hide: false }),
-          mockExercise({ hide: true }),
-          mockExercise({ hide: false }),
-          mockExercise({ hide: true }),
-        ],
-      }),
-    ];
-
-    const result = GrammarPoints.filterVisible(grammarPoints, {
-      user: { role: "admin", id: "1" },
-    });
-    expect(result).toEqual(grammarPoints);
-  });
-
-  test("filters hidden examples for non-admin", () => {
-    const grammarPoints = [
-      mockGrammarPoint({
-        order: 1,
-        hide: false,
-        examples: [
-          mockFullExample({ hide: false }),
-          mockFullExample({ hide: false }),
-          mockFullExample({ hide: true }),
-          mockFullExample({ hide: false }),
-          mockFullExample({ hide: true }),
-        ],
-      }),
-    ];
-
-    const result = GrammarPoints.filterVisible(grammarPoints, {
-      user: { role: "guest" },
-    });
-    expect(result).toEqual([
-      expect.objectContaining({
-        examples: [
-          expect.objectContaining({ hide: false }),
-          expect.objectContaining({ hide: false }),
-          expect.objectContaining({ hide: false }),
-        ],
-      }),
-    ]);
-  });
-
-  test("does not filter hidden examples for admin", () => {
-    const grammarPoints = [
-      mockGrammarPoint({
-        order: 1,
-        hide: false,
-        examples: [
-          mockFullExample({ hide: false }),
-          mockFullExample({ hide: false }),
-          mockFullExample({ hide: true }),
-          mockFullExample({ hide: false }),
-          mockFullExample({ hide: true }),
-        ],
-      }),
     ];
 
     const result = GrammarPoints.filterVisible(grammarPoints, {

--- a/packages/grammar-sdk/src/grammar-point/index.ts
+++ b/packages/grammar-sdk/src/grammar-point/index.ts
@@ -1,7 +1,5 @@
 import { err, ok, type Result } from "neverthrow";
 import { Context } from "../context";
-import { FullExamples, type FullExample } from "../example";
-import { Exercises, type Exercise } from "../exercise";
 // biome-ignore lint/suspicious/noShadowRestrictedNames: <expected>
 import { Set } from "immutable";
 
@@ -10,9 +8,6 @@ export interface GrammarPoint {
   shortTitle: string;
   order: number;
   hide: boolean;
-
-  examples: FullExample[];
-  exercises: Exercise[];
 
   torfl?: string;
   detailedTitle?: string;
@@ -30,12 +25,10 @@ export type GrammarPointLabel = {
 
 export type CreateGrammarPoint = Omit<
   GrammarPoint,
-  "id" | "order" | "examples" | "exercises" | "hide" | "labels"
+  "id" | "order" | "examples" | "hide" | "labels"
 >;
 
-export type UpdateGrammarPoint = Partial<
-  Omit<GrammarPoint, "examples" | "exercises">
-> &
+export type UpdateGrammarPoint = Partial<Omit<GrammarPoint, "examples">> &
   Pick<GrammarPoint, "id">;
 
 export const GrammarPoint = {
@@ -46,8 +39,6 @@ export const GrammarPoint = {
     return GrammarPoint.isVisible(gp, context)
       ? {
           ...gp,
-          exercises: Exercises.filterVisible(gp.exercises, context),
-          examples: FullExamples.filterVisible(gp.examples, context),
         }
       : undefined;
   },

--- a/packages/grammar-sdk/src/grammar.ts
+++ b/packages/grammar-sdk/src/grammar.ts
@@ -95,8 +95,8 @@ export const fetchExamplesByGrammarPointId = async (
   grammarPointId: string,
   context: Context,
 ): Promise<FullExample[]> => {
-  const exercises = Exercises.filterVisible(
-    await fetchExercisesByGrammarPointId(grammarPointId, context),
+  const exercises = await fetchExercisesByGrammarPointId(
+    grammarPointId,
     context,
   );
 

--- a/packages/grammar-sdk/src/grammar.ts
+++ b/packages/grammar-sdk/src/grammar.ts
@@ -1,5 +1,12 @@
 import { Context } from "./context";
-import { getGrammarPoint, getGrammarPoints } from "./db";
+import {
+  getExercisesByGrammarPointId,
+  getExercisesByGrammarPointIds,
+  getGrammarPoint,
+  getGrammarPoints,
+} from "./db";
+import { type FullExample, FullExamples } from "./example";
+import { Exercises, type ExercisesByGrammarPointId } from "./exercise";
 import { GrammarPoint, GrammarPoints } from "./grammar-point";
 
 let InMemoryCache: GrammarPoint[] | null = null;
@@ -62,7 +69,6 @@ export const fetchGrammarPoints = async (
 
 export const fetchAllGrammarPoints = async (
   context: Context,
-  include: { exercises: boolean } = { exercises: true },
 ): Promise<GrammarPoint[]> => {
   const cached = await getFromCache(context);
 
@@ -70,12 +76,42 @@ export const fetchAllGrammarPoints = async (
     return GrammarPoints.filterVisible(cached, context);
   }
 
-  const grammarPoints = await getGrammarPoints(undefined, include);
-  // Cache only if everything is included
-  if (Object.values(include).every((v) => v)) {
-    setCache(grammarPoints);
-  }
+  const grammarPoints = await getGrammarPoints();
+  setCache(grammarPoints);
   return GrammarPoints.filterVisible(grammarPoints, context);
+};
+
+export const fetchExercisesByGrammarPointId = async (
+  grammarPointId: string,
+  context: Context,
+) => {
+  return Exercises.filterVisible(
+    await getExercisesByGrammarPointId(+grammarPointId),
+    context,
+  );
+};
+
+export const fetchExamplesByGrammarPointId = async (
+  grammarPointId: string,
+  context: Context,
+): Promise<FullExample[]> => {
+  const exercises = Exercises.filterVisible(
+    await fetchExercisesByGrammarPointId(grammarPointId, context),
+    context,
+  );
+
+  return FullExamples.fromExercises(exercises);
+};
+
+export const fetchExercisesByGrammarPointIds = async (
+  grammarPointIds: string[],
+  context: Context,
+): Promise<ExercisesByGrammarPointId> => {
+  const exercises = Exercises.filterVisible(
+    await getExercisesByGrammarPointIds(grammarPointIds.map((id) => +id)),
+    context,
+  );
+  return Object.groupBy(exercises, (e) => e.grammarPointId);
 };
 
 export {

--- a/packages/grammar-sdk/tests/integration/db.test.ts
+++ b/packages/grammar-sdk/tests/integration/db.test.ts
@@ -19,7 +19,7 @@ import {
   exercisesTmp,
   grammarPointsTmp,
 } from "../../../../libs/db/schema-tmp";
-import { getGrammarPoint, putExercises } from "../../src/db";
+import { getExercisesByGrammarPointId, putExercises } from "../../src/db";
 import type { Context } from "../../src/context";
 import type { Exercise } from "../../src/exercise";
 
@@ -236,9 +236,9 @@ describe("putExercises", () => {
 
       expect(result.isOk()).toBe(true);
 
-      const created = await getGrammarPoint(1, db);
-      expect(created?.exercises.length).toBe(1);
-      expect(created?.exercises).toEqual(
+      const created = await getExercisesByGrammarPointId(1, db);
+      expect(created.length).toBe(1);
+      expect(created).toEqual(
         exercises.map(withAnyId).map((e) => ({
           ...e,
           parts: e.parts.map(withAnyId),
@@ -258,7 +258,7 @@ describe("putExercises", () => {
 
       expect(result.isOk()).toBe(true);
 
-      const created = (await getGrammarPoint(1, db))?.exercises;
+      const created = await getExercisesByGrammarPointId(1, db);
 
       expect(created).toEqual(
         exercises.map(withAnyId).map((e) => ({
@@ -309,13 +309,11 @@ describe("putExercises", () => {
       ];
 
       await putExercises(db, exercises, adminContext);
-      const result = await getGrammarPoint(1, db);
+      const result = await getExercisesByGrammarPointId(1, db);
 
-      expect(result?.exercises[0].parts).toHaveLength(3);
-      expect(result?.exercises[0].parts[0]).not.toHaveProperty(
-        "acceptableAnswers",
-      );
-      expect(result?.exercises[0].parts[1]).toMatchObject({
+      expect(result[0].parts).toHaveLength(3);
+      expect(result[0].parts[0]).not.toHaveProperty("acceptableAnswers");
+      expect(result[0].parts[1]).toMatchObject({
         acceptableAnswers: [
           { text: "Correct", description: "Good", variant: "correct" },
           { text: "Wrong", description: "Bad", variant: "incorrect" },
@@ -332,9 +330,9 @@ describe("putExercises", () => {
 
       expect(result.isOk()).toBe(true);
 
-      const created = await getGrammarPoint(1, db);
-      expect(created?.exercises.length).toBe(1);
-      expect(created?.exercises[0].hide).toBe(true);
+      const created = await getExercisesByGrammarPointId(1, db);
+      expect(created.length).toBe(1);
+      expect(created[0].hide).toBe(true);
     });
   });
 
@@ -359,8 +357,8 @@ describe("putExercises", () => {
 
       expect(result.isOk()).toBe(true);
 
-      const updated = await getGrammarPoint(1, db);
-      expect(updated?.exercises[0].hide).toBe(true);
+      const updated = await getExercisesByGrammarPointId(1, db);
+      expect(updated[0].hide).toBe(true);
     });
 
     test("should update exercise order", async () => {
@@ -383,8 +381,8 @@ describe("putExercises", () => {
 
       expect(result.isOk()).toBe(true);
 
-      const updated = await getGrammarPoint(1, db);
-      expect(updated?.exercises[0].order).toBe(5);
+      const updated = await getExercisesByGrammarPointId(1, db);
+      expect(updated[0].order).toBe(5);
     });
 
     test("should update exercise parts and translation parts", async () => {
@@ -474,7 +472,7 @@ describe("putExercises", () => {
 
       expect(result.isOk()).toBe(true);
 
-      const updated = (await getGrammarPoint(1, db))?.exercises;
+      const updated = await getExercisesByGrammarPointId(1, db);
 
       expect(updated).toEqual(
         update.map(withAnyId).map((e) => ({
@@ -567,12 +565,12 @@ describe("putExercises", () => {
 
       expect(result.isOk()).toBe(true);
 
-      const updated = (await getGrammarPoint(1, db))?.exercises;
+      const updated = await getExercisesByGrammarPointId(1, db);
 
       // @ts-expect-error - acceptableAnswers is optional in ExercisePart, but should be present in answer parts
-      expect(updated?.[0].parts[1].acceptableAnswers).toHaveLength(2);
+      expect(updated[0].parts[1].acceptableAnswers).toHaveLength(2);
       // @ts-expect-error - acceptableAnswers is optional in ExercisePart, but should be present in answer parts
-      expect(updated?.[0].parts[1].acceptableAnswers).toEqual(
+      expect(updated[0].parts[1].acceptableAnswers).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             text: "Existing correct answer",
@@ -611,12 +609,12 @@ describe("putExercises", () => {
 
       expect(result.isOk()).toBe(true);
 
-      const allExercises = await getGrammarPoint(1, db);
+      const allExercises = await getExercisesByGrammarPointId(1, db);
 
-      expect(allExercises?.exercises.length).toBe(2);
-      expect(allExercises?.exercises[0].id).toBe(existing.id);
-      expect(allExercises?.exercises[0].hide).toBe(true);
-      expect(allExercises?.exercises[1].id).not.toBe(existing.id);
+      expect(allExercises.length).toBe(2);
+      expect(allExercises[0].id).toBe(existing.id);
+      expect(allExercises[0].hide).toBe(true);
+      expect(allExercises[1].id).not.toBe(existing.id);
     });
   });
 });

--- a/packages/space-repetition/index.ts
+++ b/packages/space-repetition/index.ts
@@ -2,6 +2,7 @@ import {
   fetchAllGrammarPoints,
   fetchExercisesByGrammarPointId,
   fetchExercisesByGrammarPointIds,
+  fetchGrammarPoints,
   type Context,
   type Exercise,
 } from "grammar-sdk";
@@ -82,34 +83,51 @@ export const getNextRound = async (user: User): Promise<Round[]> => {
   const spaceRepetition = SpaceRepetition(attempts);
   const nextRound = spaceRepetition.nextRound(algorithm, settings);
 
-  const exercisesByGrammarPointIds = Object.values(
-    await fetchExercisesByGrammarPointIds(
-      nextRound.map((r) => r.grammarPointId),
-      contextFromUser(user),
-    ),
-  )
-    .map((exercises, index) => {
-      if (!exercises || exercises.length === 0) {
+  const grammarPoints = await fetchGrammarPoints(
+    nextRound.map((r) => r.grammarPointId),
+    contextFromUser(user),
+  );
+
+  const exercises = await fetchExercisesByGrammarPointIds(
+    nextRound.map((r) => r.grammarPointId),
+    contextFromUser(user),
+  );
+
+  return grammarPoints
+    .toSorted((a, b) => a.order - b.order)
+    .map((gp) => {
+      const round = nextRound.find((r) => r.grammarPointId === gp.id);
+      const sortedExercises = exercises[gp.id]?.sort(
+        (a, b) => a.order - b.order,
+      );
+      if (!round || !sortedExercises) {
         console.warn(
-          "No exercises found for grammar point",
-          nextRound[index].grammarPointId,
+          `Round or exercises not found for grammar point ${gp.id}`,
+          round,
+          sortedExercises,
         );
         return undefined;
       }
-      const sortedExercises = exercises.sort((a, b) => a.order - b.order);
-      return sortedExercises[
-        calculateExerciseOrderByStage(
-          sortedExercises.length,
-          nextRound[index].stage,
-        )
-      ];
-    })
-    .filter((v): v is Exercise => !!v);
 
-  return exercisesByGrammarPointIds.map((exercise, index) => ({
-    exercise,
-    stage: nextRound[index].stage as Stage,
-  }));
+      const nextExercise =
+        sortedExercises[
+          calculateExerciseOrderByStage(sortedExercises.length, round.stage)
+        ];
+
+      if (!nextExercise) {
+        console.warn(
+          `Next exercise not found for grammar point ${gp.id} and stage ${round.stage}`,
+          sortedExercises,
+        );
+        return undefined;
+      }
+
+      return {
+        exercise: nextExercise,
+        stage: round.stage,
+      };
+    })
+    .filter((v): v is { exercise: Exercise; stage: Stage } => !!v);
 };
 
 export const countNextRound = async (user: User): Promise<number> => {

--- a/packages/space-repetition/index.ts
+++ b/packages/space-repetition/index.ts
@@ -1,10 +1,19 @@
-import { fetchAllGrammarPoints, type Context } from "grammar-sdk";
+import {
+  fetchAllGrammarPoints,
+  fetchExercisesByGrammarPointId,
+  fetchExercisesByGrammarPointIds,
+  type Context,
+  type Exercise,
+} from "grammar-sdk";
 import { Map as IMap, Seq } from "immutable";
 import { db } from "../../libs/db";
 import type { User } from "../../src/models/user";
 import { NaiveAlgorithm } from "./src/NaiveAlgorithm";
 import { Session } from "./src/session";
-import { SpaceRepetition } from "./src/SpaceRepetition";
+import {
+  calculateExerciseOrderByStage,
+  SpaceRepetition,
+} from "./src/SpaceRepetition";
 import {
   addToRepetitions,
   getAttempts,
@@ -14,10 +23,11 @@ import {
 } from "./src/SpaceRepetitionRepository";
 import { MockStageSettings, StageSettings } from "./src/StageSettings";
 import type { Attempt } from "./src/types/Attempt";
-import type { Lesson } from "./src/types/Lesson";
+import { Lesson } from "./src/types/Lesson";
 import type { Schedule } from "./src/types/Schedule";
 import { countStreak as countStreakUtils } from "./src/utils";
 import { isUserAdmin } from "../../libs/auth/admin";
+import type { Round } from "./src/types/Round";
 
 const algorithm = NaiveAlgorithm;
 const settings = {
@@ -38,11 +48,24 @@ export const getLessons = async (
   amount: number,
   user: User,
 ): Promise<Lesson[]> => {
-  const grammarPoints = await fetchAllGrammarPoints(contextFromUser(user));
   const attempts = await getAttempts(db, user);
 
+  const grammarPoints = await fetchAllGrammarPoints(contextFromUser(user));
+
   const spaceRepetition = SpaceRepetition(attempts);
-  return spaceRepetition.nextLessons(amount, grammarPoints);
+  const nextGrammarPoints = spaceRepetition.nextGrammarPointsForLessons(
+    amount,
+    grammarPoints,
+  );
+  return Promise.all(
+    nextGrammarPoints.map(async (gp) => {
+      const exercises = await fetchExercisesByGrammarPointId(
+        gp.id,
+        contextFromUser(user),
+      );
+      return Lesson({ ...gp, exercises });
+    }),
+  ).then((lessons) => lessons.filter((l): l is Lesson => !!l));
 };
 
 export const addAttempt = async (
@@ -52,18 +75,37 @@ export const addAttempt = async (
   await saveAttempt(db, attempt, user);
 };
 
-export const getNextRound = async (user: User): Promise<Lesson[]> => {
+export const getNextRound = async (user: User): Promise<Round[]> => {
   const attempts = await getAttempts(db, user);
-  const grammarPoints = await fetchAllGrammarPoints(contextFromUser(user));
 
   const spaceRepetition = SpaceRepetition(attempts);
-  const nextRound = spaceRepetition.nextRound(
-    algorithm,
-    settings,
-    grammarPoints,
-  );
+  const nextRound = spaceRepetition.nextRound(algorithm, settings);
 
-  return nextRound;
+  const exercisesByGrammarPointIds = Object.values(
+    await fetchExercisesByGrammarPointIds(
+      nextRound.map((r) => r.grammarPointId),
+      contextFromUser(user),
+    ),
+  )
+    .map((exercises, index) => {
+      if (!exercises || exercises.length === 0) {
+        console.warn(
+          "No exercises found for grammar point",
+          nextRound[index].grammarPointId,
+        );
+        return undefined;
+      }
+      const sortedExercises = exercises.sort((a, b) => a.order - b.order);
+      return sortedExercises[
+        calculateExerciseOrderByStage(
+          sortedExercises.length,
+          nextRound[index].stage,
+        )
+      ];
+    })
+    .filter((v): v is Exercise => !!v);
+
+  return exercisesByGrammarPointIds;
 };
 
 export const countNextRound = async (user: User): Promise<number> => {
@@ -85,9 +127,7 @@ export const countStreak = async (
 
 export const getInReviewByTorfl = async (user: User) => {
   const schedule = await getSchedule(user);
-  const grammar = await fetchAllGrammarPoints(contextFromUser(user), {
-    exercises: false,
-  });
+  const grammar = await fetchAllGrammarPoints(contextFromUser(user));
 
   const grammarPointsById = IMap(grammar.map((v) => [v.id, v]));
 
@@ -126,7 +166,7 @@ export const getSessionResult = async (user: User, sessionId: string) => {
   return Session.calculateResult(session);
 };
 
-export type { Attempt } from "./src/types/Attempt";
+export * from "./src/types/Attempt";
 export type { Lesson } from "./src/types/Lesson";
 export type { Schedule } from "./src/types/Schedule";
 export type { Stage } from "./src/types/Stage";

--- a/packages/space-repetition/index.ts
+++ b/packages/space-repetition/index.ts
@@ -28,6 +28,7 @@ import type { Schedule } from "./src/types/Schedule";
 import { countStreak as countStreakUtils } from "./src/utils";
 import { isUserAdmin } from "../../libs/auth/admin";
 import type { Round } from "./src/types/Round";
+import type { Stage } from "./src/types/Stage";
 
 const algorithm = NaiveAlgorithm;
 const settings = {
@@ -105,7 +106,10 @@ export const getNextRound = async (user: User): Promise<Round[]> => {
     })
     .filter((v): v is Exercise => !!v);
 
-  return exercisesByGrammarPointIds;
+  return exercisesByGrammarPointIds.map((exercise, index) => ({
+    exercise,
+    stage: nextRound[index].stage as Stage,
+  }));
 };
 
 export const countNextRound = async (user: User): Promise<number> => {

--- a/packages/space-repetition/src/SpaceRepetition.test.ts
+++ b/packages/space-repetition/src/SpaceRepetition.test.ts
@@ -1,12 +1,6 @@
-import { describe, expect, test, vi } from "vitest";
-import {
-  calculateExerciseOrderByStage,
-  SpaceRepetition,
-} from "./SpaceRepetition";
+import { describe, expect, test } from "vitest";
+import { calculateExerciseOrderByStage } from "./SpaceRepetition";
 import type { Stage } from "./types/Stage";
-import type { RepetitionAlgorithm } from "./SpaceRepetition";
-import { mockGrammarPoint } from "grammar-sdk/mocks";
-import type { GrammarPoint } from "grammar-sdk";
 
 describe("calculateNextExerciseOrder", () => {
   test.each([
@@ -34,72 +28,5 @@ describe("calculateNextExerciseOrder", () => {
     expect(calculateExerciseOrderByStage(exercisesNumber, stage as Stage)).toBe(
       expected,
     );
-  });
-});
-
-describe("nextRound", () => {
-  test("loops to first exercise when stage exceeds number of exercises", () => {
-    const mockAlgorithm: RepetitionAlgorithm = {
-      getSchedule: vi.fn().mockReturnValue([
-        {
-          grammarPointId: "gp1",
-          stage: 4,
-          availableAt: new Date(0),
-        },
-      ]),
-    };
-
-    const settings = {
-      stageMinutes: { 0: 1, 1: 10, 2: 60, 3: 1440, 4: 10080 } as Record<
-        Stage,
-        number
-      >,
-      stageDowngradeMultiplier: 2,
-    };
-
-    const gp = mockGrammarPoint({ id: "gp1" });
-    const grammarPoints: GrammarPoint[] = [
-      {
-        ...gp,
-        torfl: "A1",
-        exercises: [
-          {
-            hide: false,
-            grammarPointId: "gp1",
-            parts: [],
-            translationParts: [],
-            order: 0,
-          },
-          {
-            hide: false,
-            grammarPointId: "gp1",
-            parts: [],
-            translationParts: [],
-            order: 1,
-          },
-          {
-            hide: false,
-            grammarPointId: "gp1",
-            parts: [],
-            translationParts: [],
-            order: 2,
-          },
-          {
-            hide: false,
-            grammarPointId: "gp1",
-            parts: [],
-            translationParts: [],
-            order: 3,
-          },
-        ],
-      },
-    ];
-
-    const sr = SpaceRepetition([]);
-    const result = sr.nextRound(mockAlgorithm, settings, grammarPoints);
-
-    expect(result).toHaveLength(1);
-    expect(result[0].exercise.order).toBe(0);
-    expect(result[0].stage).toBe(4);
   });
 });

--- a/packages/space-repetition/src/SpaceRepetition.ts
+++ b/packages/space-repetition/src/SpaceRepetition.ts
@@ -1,10 +1,8 @@
 import { isBefore } from "@formkit/tempo";
 import type { Attempt } from "./types/Attempt";
-import { Lesson } from "./types/Lesson";
 import type { Stage } from "./types/Stage";
 import type { Schedule } from "./types/Schedule";
 import type { GrammarPoint } from "grammar-sdk";
-import type { GrammarPointReview } from "./types/GrammarPointReview";
 
 export interface Settings {
   stageMinutes: Record<Stage, number>;
@@ -30,13 +28,12 @@ export const calculateExerciseOrderByStage = (
 
 interface SpaceRepetition {
   repeatingGrammarPoints(): string[];
-  nextLessons(amount: number, grammar: GrammarPoint[]): Lesson[];
+  nextGrammarPointsForLessons(
+    amount: number,
+    grammarPoints: GrammarPoint[],
+  ): GrammarPoint[];
   getSchedule(algorithm: RepetitionAlgorithm, settings: Settings): Schedule;
-  nextRound(
-    algorithm: RepetitionAlgorithm,
-    settings: Settings,
-    grammar: GrammarPoint[],
-  ): GrammarPointReview[];
+  nextRound(algorithm: RepetitionAlgorithm, settings: Settings): Repetition[];
 }
 
 export const SpaceRepetition = (attempts: Attempt[]): SpaceRepetition => {
@@ -44,9 +41,12 @@ export const SpaceRepetition = (attempts: Attempt[]): SpaceRepetition => {
     return Array.from(new Set(attempts.map((t) => t.grammarPointId)).values());
   };
 
-  const nextLessons = (amount: number, grammar: GrammarPoint[]): Lesson[] => {
+  const nextGrammarPointsForLessons = (
+    amount: number,
+    grammarPoints: GrammarPoint[],
+  ): GrammarPoint[] => {
     const reviewMap = new Map(repeatingGrammarPoints().map((r) => [r, true]));
-    const gpNotInReview = grammar.filter((gp) => !reviewMap.get(gp.id));
+    const gpNotInReview = grammarPoints.filter((gp) => !reviewMap.has(gp.id));
 
     const result = gpNotInReview
       .toSorted(
@@ -54,9 +54,7 @@ export const SpaceRepetition = (attempts: Attempt[]): SpaceRepetition => {
           (a.order ?? Number.MAX_SAFE_INTEGER) -
           (b.order ?? Number.MAX_SAFE_INTEGER),
       )
-      .slice(0, amount)
-      .map(Lesson)
-      .filter((v): v is Lesson => !!v);
+      .slice(0, amount);
     return result;
   };
 
@@ -64,34 +62,14 @@ export const SpaceRepetition = (attempts: Attempt[]): SpaceRepetition => {
     return algorithm.getSchedule(attempts, settings);
   };
 
-  const nextRound = (
-    algorithm: RepetitionAlgorithm,
-    settings: Settings,
-    grammar: GrammarPoint[],
-  ): GrammarPointReview[] => {
+  const nextRound = (algorithm: RepetitionAlgorithm, settings: Settings) => {
     const schedule = algorithm.getSchedule(attempts, settings);
-
-    return schedule
-      .filter((r) => isBefore(r.availableAt, new Date()))
-      .map((r) => {
-        const gp = grammar.find((gp) => gp.id === r.grammarPointId);
-
-        if (!gp) return undefined;
-        const { exercises, ...info } = gp;
-
-        return {
-          ...info,
-          exercise:
-            exercises[calculateExerciseOrderByStage(exercises.length, r.stage)],
-          stage: r.stage,
-        };
-      })
-      .filter((v): v is GrammarPointReview => !!v);
+    return schedule.filter((r) => isBefore(r.availableAt, new Date()));
   };
 
   return {
     repeatingGrammarPoints,
-    nextLessons,
+    nextGrammarPointsForLessons,
     getSchedule,
     nextRound,
   };

--- a/packages/space-repetition/src/session/index.ts
+++ b/packages/space-repetition/src/session/index.ts
@@ -1,11 +1,17 @@
 import { Seq } from "immutable";
-import type { Attempt } from "../types/Attempt";
+import type { Attempt, LocalAttempt } from "../types/Attempt";
 
-export type Session = {
+type AttemptType<Local extends "local" | "remote"> = Local extends "local"
+  ? LocalAttempt
+  : Attempt;
+
+export type Session<Local extends "local" | "remote" = "remote"> = {
   sessionId: string;
-  attempts: Attempt[];
+  attempts: AttemptType<Local>[];
 };
-export function Session(attempts: Attempt[]): Session {
+export function Session<Local extends "local" | "remote" = "remote">(
+  attempts: AttemptType<Local>[],
+): Session<Local> {
   const sessionId = attempts.at(0)?.reviewSessionId;
   if (!sessionId || !attempts.every((a) => a.reviewSessionId === sessionId)) {
     throw new Error(
@@ -19,21 +25,23 @@ export function Session(attempts: Attempt[]): Session {
   };
 }
 
-export type SessionResult = {
+export type AnySessionResult = SessionResult<"local"> | SessionResult<"remote">;
+
+export type SessionResult<Local extends "local" | "remote" = "remote"> = {
   sessionId: string;
-  attempts: Attempt[];
+  attempts: (Local extends "local" ? LocalAttempt : Attempt)[];
   correct: number;
   total: number;
 };
 
 export namespace Session {
-  export const calculateResult = ({
+  export const calculateResult = <Local extends "local" | "remote" = "remote">({
     attempts,
     sessionId,
-  }: Session): SessionResult => {
+  }: Session<Local>): SessionResult<Local> => {
     const attemptsByGpStage = Seq(attempts).groupBy(
       (a) => `${a.grammarPointId}-${a.stage}`,
-    );
+    ) as Immutable.Map<string, Seq.Indexed<AttemptType<Local>>>;
 
     const meaningfulAttempts = Array.from(
       attemptsByGpStage
@@ -46,7 +54,7 @@ export namespace Session {
             .sort((a, b) => +a.answeredAt - +b.answeredAt)
             .last();
         })
-        .filter((a): a is Attempt => !!a)
+        .filter((a): a is AttemptType<Local> => !!a)
         .values(),
     );
 

--- a/packages/space-repetition/src/types/Attempt.ts
+++ b/packages/space-repetition/src/types/Attempt.ts
@@ -1,3 +1,4 @@
+import type { Exercise } from "grammar-sdk/exercise";
 import type { Stage } from "./Stage";
 
 export type Attempt = {
@@ -7,4 +8,8 @@ export type Attempt = {
   isCorrect: boolean;
   answeredAt: Date;
   reviewSessionId: string;
+};
+
+export type LocalAttempt = Attempt & {
+  exercise: Exercise;
 };

--- a/packages/space-repetition/src/types/GrammarPointReview.ts
+++ b/packages/space-repetition/src/types/GrammarPointReview.ts
@@ -1,10 +1,10 @@
-import type { GrammarPoint } from "grammar-sdk";
+import type { Exercise } from "grammar-sdk";
 import type { Stage } from "./Stage";
 
 /**
  * Grammar point with exercise and stage to use as a part of a review round in space repetition session
  */
-export type GrammarPointReview = Omit<GrammarPoint, "exercises"> & {
-  exercise: GrammarPoint["exercises"][number];
+export type GrammarPointReview = {
+  exercise: Exercise;
   stage: Stage;
 };

--- a/packages/space-repetition/src/types/Lesson.test.ts
+++ b/packages/space-repetition/src/types/Lesson.test.ts
@@ -1,17 +1,17 @@
-import type { GrammarPoint } from "grammar-sdk";
-import { mockGrammarPoint } from "grammar-sdk/mocks";
+import { mockExercises, mockGrammarPoint } from "grammar-sdk/mocks";
 import { expect, test } from "vitest";
 import { Lesson } from "./Lesson";
 
 test("Lesson", () => {
-  const gp = mockGrammarPoint() as GrammarPoint;
-  const { exercises, ...noEx } = gp;
+  const gp = mockGrammarPoint();
 
-  const result = Lesson(gp);
+  const exercises = mockExercises(12, gp.id);
+
+  const result = Lesson({ ...gp, exercises });
 
   expect(result?.exercise.order).toBe(0);
   expect(result).toEqual({
-    ...noEx,
-    exercise: gp.exercises.at(0),
+    ...gp,
+    exercise: exercises.at(0),
   });
 });

--- a/packages/space-repetition/src/types/Lesson.ts
+++ b/packages/space-repetition/src/types/Lesson.ts
@@ -11,10 +11,10 @@ export const Lesson = ({
 }: GrammarPoint & {
   exercises: Exercise[];
 }): Lesson | undefined => {
-  const lastExercise = Seq(exercises).minBy((e) => e.order);
-  if (!lastExercise) return undefined;
+  const firstExercise = Seq(exercises).minBy((e) => e.order);
+  if (!firstExercise) return undefined;
   return {
     ...gp,
-    exercise: lastExercise,
+    exercise: firstExercise,
   };
 };

--- a/packages/space-repetition/src/types/Lesson.ts
+++ b/packages/space-repetition/src/types/Lesson.ts
@@ -1,14 +1,16 @@
-import type { GrammarPoint } from "grammar-sdk";
+import type { Exercise, GrammarPoint } from "grammar-sdk";
 import { Seq } from "immutable";
 
-export type Lesson = Omit<GrammarPoint, "exercises"> & {
-  exercise: GrammarPoint["exercises"][number];
+export type Lesson = GrammarPoint & {
+  exercise: Exercise;
 };
 
 export const Lesson = ({
   exercises,
   ...gp
-}: GrammarPoint): Lesson | undefined => {
+}: GrammarPoint & {
+  exercises: Exercise[];
+}): Lesson | undefined => {
   const lastExercise = Seq(exercises).minBy((e) => e.order);
   if (!lastExercise) return undefined;
   return {

--- a/packages/space-repetition/src/types/Round.ts
+++ b/packages/space-repetition/src/types/Round.ts
@@ -1,0 +1,3 @@
+import type { Exercise } from "grammar-sdk";
+
+export type Round = Exercise;

--- a/packages/space-repetition/src/types/Round.ts
+++ b/packages/space-repetition/src/types/Round.ts
@@ -1,3 +1,4 @@
 import type { Exercise } from "grammar-sdk";
+import type { Stage } from "./Stage";
 
-export type Round = Exercise;
+export type Round = { exercise: Exercise; stage: Stage };

--- a/src/actions/gp-management.ts
+++ b/src/actions/gp-management.ts
@@ -1,10 +1,14 @@
 import { ActionError, defineAction } from "astro:actions";
 import { z } from "astro/zod";
-import { createLabel, exerciseSchema, getLabels } from "grammar-sdk";
+import {
+  createLabel,
+  exerciseSchema,
+  fetchExercisesByGrammarPointId,
+  getLabels,
+} from "grammar-sdk";
 import { contextFromAstro } from "~/libs/context";
 import {
   type AuthorizationError,
-  fetchGrammarPoint,
   createGrammarPoint,
   isAuthorizationError,
   putExercises,
@@ -111,17 +115,17 @@ export const gpManagement = {
       if (result.isErr()) {
         handleError(result.error);
       }
-      const gp = await fetchGrammarPoint(
+      const exercises = await fetchExercisesByGrammarPointId(
         input[0].grammarPointId,
         contextFromAstro(context),
       );
-      if (!gp) {
+      if (!exercises) {
         throw new ActionError({
           code: "NOT_FOUND",
           message: "Grammar point not found.",
         });
       }
-      return gp.exercises;
+      return exercises;
     },
   }),
   createLabel: defineAction({

--- a/src/actions/gp-management.ts
+++ b/src/actions/gp-management.ts
@@ -119,7 +119,7 @@ export const gpManagement = {
         input[0].grammarPointId,
         contextFromAstro(context),
       );
-      if (!exercises) {
+      if (!exercises.length) {
         throw new ActionError({
           code: "NOT_FOUND",
           message: "Grammar point not found.",

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -1,7 +1,7 @@
 import { ActionError, defineAction } from "astro:actions";
 import { PUBLIC_URL } from "astro:env/server";
 import { z } from "astro/zod";
-import { fetchGrammarPoint } from "grammar-sdk";
+import { fetchExamplesByGrammarPointId, fetchGrammarPoint } from "grammar-sdk";
 import { db } from "libs/db";
 import { createSupabaseServerInstance } from "libs/supabase";
 import { saveFeedback } from "packages/feedback";
@@ -141,13 +141,29 @@ export const server = {
       };
     },
   }),
-  grammarPoint: defineAction({
+  grammarPointWithExamples: defineAction({
     accept: "json",
     input: z.object({
       grammarPointId: z.string(),
     }),
     handler: async (input, context) => {
-      return fetchGrammarPoint(input.grammarPointId, contextFromAstro(context));
+      const [gp, examples] = await Promise.all([
+        fetchGrammarPoint(input.grammarPointId, contextFromAstro(context)),
+        fetchExamplesByGrammarPointId(
+          input.grammarPointId,
+          contextFromAstro(context),
+        ),
+      ]);
+      if (!gp) {
+        throw new ActionError({
+          code: "NOT_FOUND",
+          message: "Grammar point not found",
+        });
+      }
+      return {
+        ...gp,
+        examples,
+      };
     },
   }),
   saveAttempt: defineAction({

--- a/src/components/solid/Exercise/CommonSessionResults.tsx
+++ b/src/components/solid/Exercise/CommonSessionResults.tsx
@@ -1,0 +1,78 @@
+import type { Example as ExampleImpl } from "grammar-sdk/example";
+import { For, Show } from "solid-js";
+import { Card, CardContent, CardHeader } from "ui/card";
+import { Example } from "../example/Example";
+import type { AnySessionResult } from "packages/space-repetition/src/session";
+
+export const CommonSessionResult = ({
+  answers,
+  sessionResult,
+}: {
+  answers: {
+    ru: ExampleImpl;
+    en: ExampleImpl;
+    isCorrect: boolean;
+    grammarPointId: string;
+  }[];
+  sessionResult?: AnySessionResult;
+}) => {
+  const backTo = () => `/sr/review/${sessionResult?.sessionId}/result`;
+  const grammarHref = (gpId: string) => `/grammar/${gpId}?backTo=${backTo()}`;
+
+  return (
+    <Show when={sessionResult}>
+      {(sessionResult) => (
+        <div>
+          <h1 class="mb-5 text-center text-3xl">Молодец!</h1>
+
+          <div class="grid grid-cols-1 gap-5 md:grid-cols-4">
+            <Accuracy
+              total={sessionResult().total}
+              correct={sessionResult().correct}
+            />
+            <div class="flex flex-col gap-3 md:col-span-3">
+              <For each={answers}>
+                {(answer) => (
+                  <Example
+                    variant={answer.isCorrect ? "correct" : "wrong"}
+                    ru={answer.ru}
+                    en={answer.en}
+                    alwaysShow
+                    grammarHref={grammarHref(answer.grammarPointId)}
+                  />
+                )}
+              </For>
+            </div>
+          </div>
+        </div>
+      )}
+    </Show>
+  );
+};
+
+const Accuracy = (props: {
+  class?: string;
+  total: number;
+  correct: number;
+}) => {
+  return (
+    <Card class="max-h-40" variant="outlined">
+      <CardHeader>
+        <div class="text-center text-3xl">
+          {Math.floor((props.correct / props.total) * 100)}%
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div class="flex flex-row justify-center gap-5">
+          <div>
+            Correct: <span class="text-success">{props.correct}</span>
+          </div>
+          <div>
+            Incorrect:{" "}
+            <span class="text-error">{props.total - props.correct}</span>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/components/solid/Exercise/CommonSessionResults.tsx
+++ b/src/components/solid/Exercise/CommonSessionResults.tsx
@@ -59,7 +59,10 @@ const Accuracy = (props: {
     <Card class="max-h-40" variant="outlined">
       <CardHeader>
         <div class="text-center text-3xl">
-          {props.total > 0 ? Math.floor((props.correct / props.total) * 100) : 0}%
+          {props.total > 0
+            ? Math.floor((props.correct / props.total) * 100)
+            : 0}
+          %
         </div>
       </CardHeader>
       <CardContent>

--- a/src/components/solid/Exercise/CommonSessionResults.tsx
+++ b/src/components/solid/Exercise/CommonSessionResults.tsx
@@ -59,7 +59,7 @@ const Accuracy = (props: {
     <Card class="max-h-40" variant="outlined">
       <CardHeader>
         <div class="text-center text-3xl">
-          {Math.floor((props.correct / props.total) * 100)}%
+          {props.total > 0 ? Math.floor((props.correct / props.total) * 100) : 0}%
         </div>
       </CardHeader>
       <CardContent>

--- a/src/components/solid/Exercise/Exercise.tsx
+++ b/src/components/solid/Exercise/Exercise.tsx
@@ -130,8 +130,9 @@ export const Exercise = (props: ExerciseProps) => {
 const LoadingGrammarPoint = (props: { grammarPointId: string }) => {
   const [gp] = createResource(
     { grammarPointId: props.grammarPointId },
-    actions.grammarPoint,
+    actions.grammarPointWithExamples,
   );
+
   let ref!: HTMLDivElement;
 
   return (

--- a/src/components/solid/Exercise/Exercises.tsx
+++ b/src/components/solid/Exercise/Exercises.tsx
@@ -34,15 +34,18 @@ export const Exercises = (props: {
   ) => {
     const e = exercise();
     if (e) {
-      saveAttempt({
-        answer: result.answer,
-        isCorrect: result.correct,
-        answeredAt: new Date(),
-        grammarPointId: e.grammarPointId,
-        reviewSessionId: sessionId,
-        stage: exercise()?.stage ?? 0,
-        exerciseOrder: e.order,
-      });
+      saveAttempt(
+        {
+          answer: result.answer,
+          isCorrect: result.correct,
+          answeredAt: new Date(),
+          grammarPointId: e.grammarPointId,
+          reviewSessionId: sessionId,
+          stage: exercise()?.stage ?? 0,
+          exerciseOrder: e.order,
+        },
+        e,
+      );
     }
 
     setExercisesLeft((left) =>

--- a/src/components/solid/Exercise/LocalSessionResult.tsx
+++ b/src/components/solid/Exercise/LocalSessionResult.tsx
@@ -33,7 +33,12 @@ export const LocalSessionResult = () => {
           grammarPointId: attempt.grammarPointId,
         };
       })
-      .filter((answer) => answer !== undefined) as {
+      .filter(
+        (answer) =>
+          answer !== undefined &&
+          answer.ru !== undefined &&
+          answer.en !== undefined,
+      ) as {
       ru: ExampleImpl;
       en: ExampleImpl;
       isCorrect: boolean;

--- a/src/components/solid/Exercise/LocalSessionResult.tsx
+++ b/src/components/solid/Exercise/LocalSessionResult.tsx
@@ -1,6 +1,6 @@
 import { getLocalSessionResults } from "@services/practice";
 import { Example as ExampleImpl } from "grammar-sdk/example";
-import { createEffect, createSignal } from "solid-js";
+import { createSignal, onMount } from "solid-js";
 import { CommonSessionResult } from "./CommonSessionResults";
 
 export const LocalSessionResult = () => {
@@ -8,7 +8,7 @@ export const LocalSessionResult = () => {
     getLocalSessionResults(),
   );
 
-  createEffect(() => {
+  onMount(() => {
     setSessionResult(getLocalSessionResults());
   });
 

--- a/src/components/solid/Exercise/LocalSessionResult.tsx
+++ b/src/components/solid/Exercise/LocalSessionResult.tsx
@@ -1,0 +1,46 @@
+import { getLocalSessionResults } from "@services/practice";
+import { Example as ExampleImpl } from "grammar-sdk/example";
+import { createEffect, createSignal } from "solid-js";
+import { CommonSessionResult } from "./CommonSessionResults";
+
+export const LocalSessionResult = () => {
+  const [sessionResult, setSessionResult] = createSignal(
+    getLocalSessionResults(),
+  );
+
+  createEffect(() => {
+    setSessionResult(getLocalSessionResults());
+  });
+
+  const answers = () => {
+    const session = sessionResult();
+    if (!session) return [];
+
+    return session.attempts
+      .map(({ exercise, ...attempt }) => {
+        return {
+          ...exercise,
+          ru: exercise.parts
+            ? ExampleImpl.replaceAnswer(
+                ExampleImpl.fromExerciseParts(exercise.parts),
+                attempt.answer,
+              )
+            : undefined,
+          en: exercise.translationParts
+            ? ExampleImpl.fromExerciseParts(exercise.translationParts)
+            : undefined,
+          isCorrect: attempt.isCorrect,
+          grammarPointId: attempt.grammarPointId,
+        };
+      })
+      .filter((answer) => answer !== undefined) as {
+      ru: ExampleImpl;
+      en: ExampleImpl;
+      isCorrect: boolean;
+      grammarPointId: string;
+    }[];
+  };
+  return (
+    <CommonSessionResult answers={answers()} sessionResult={sessionResult()} />
+  );
+};

--- a/src/components/solid/Exercise/SessionResult.tsx
+++ b/src/components/solid/Exercise/SessionResult.tsx
@@ -1,44 +1,41 @@
-import { getPracticeSessionResults } from "@services/practice";
-import type { GrammarPoint } from "grammar-sdk";
-import type { Exercise as ExerciseType } from "grammar-sdk/exercise";
+import type {
+  ExercisesByGrammarPointId,
+  Exercise as ExerciseType,
+} from "grammar-sdk/exercise";
 import { Example as ExampleImpl } from "grammar-sdk/example";
-import { For, Show } from "solid-js";
 import type { SessionResult as SessionResultType } from "space-repetition/session";
-import { Card, CardContent, CardHeader } from "ui/card";
-import { Example } from "../example/Example";
 import { calculateExerciseOrderByStage } from "packages/space-repetition/src/SpaceRepetition";
+import { CommonSessionResult } from "./CommonSessionResults";
 
 export const SessionResult = (props: {
-  sessionResult?: SessionResultType;
-  grammar: GrammarPoint[];
+  sessionResult: SessionResultType;
+  exercises: ExercisesByGrammarPointId;
 }) => {
-  const sessionResult = () =>
-    props.sessionResult ?? getPracticeSessionResults();
-
   const answers = () => {
-    const session = sessionResult();
+    const session = props.sessionResult;
     if (!session) return [];
 
     return session.attempts
       .map((attempt) => {
-        const gp = props.grammar.find((gp) => gp.id === attempt.grammarPointId);
-        if (!gp) {
+        const exercises = props.exercises[attempt.grammarPointId];
+        if (!exercises) {
           console.warn(
-            `Grammar point with id ${attempt.grammarPointId} not found`,
+            `Exercises for grammar point with id ${attempt.grammarPointId} not found`,
           );
           return undefined;
         }
+
         // TODO: session result should return the example, so we don't have to calculate the order and replace the answer on the client
         const order = calculateExerciseOrderByStage(
-          gp.exercises.length,
+          exercises.length,
           attempt.stage,
         );
-        const exercise: ExerciseType | undefined = gp.exercises.find(
+        const exercise: ExerciseType | undefined = exercises.find(
           (e) => e.order === order,
         );
         if (!exercise) {
           console.warn(
-            `Exercise with order ${order} not found for grammar point ${gp.id}`,
+            `Exercise with order ${order} not found for grammar point ${attempt.grammarPointId}`,
           );
           return undefined;
         }
@@ -66,64 +63,10 @@ export const SessionResult = (props: {
     }[];
   };
 
-  const backTo = () => `/sr/review/${sessionResult()?.sessionId}/result`;
-
-  const grammarHref = (gpId: string) => `/grammar/${gpId}?backTo=${backTo()}`;
-
   return (
-    <Show when={sessionResult()}>
-      {(sessionResult) => (
-        <div>
-          <h1 class="mb-5 text-center text-3xl">Молодец!</h1>
-
-          <div class="grid grid-cols-1 gap-5 md:grid-cols-4">
-            <Accuracy
-              total={sessionResult().total}
-              correct={sessionResult().correct}
-            />
-            <div class="flex flex-col gap-3 md:col-span-3">
-              <For each={answers()}>
-                {(answer) => (
-                  <Example
-                    variant={answer.isCorrect ? "correct" : "wrong"}
-                    ru={answer.ru}
-                    en={answer.en}
-                    alwaysShow
-                    grammarHref={grammarHref(answer.grammarPointId)}
-                  />
-                )}
-              </For>
-            </div>
-          </div>
-        </div>
-      )}
-    </Show>
-  );
-};
-
-const Accuracy = (props: {
-  class?: string;
-  total: number;
-  correct: number;
-}) => {
-  return (
-    <Card class="max-h-40" variant="outlined">
-      <CardHeader>
-        <div class="text-center text-3xl">
-          {Math.floor((props.correct / props.total) * 100)}%
-        </div>
-      </CardHeader>
-      <CardContent>
-        <div class="flex flex-row justify-center gap-5">
-          <div>
-            Correct: <span class="text-success">{props.correct}</span>
-          </div>
-          <div>
-            Incorrect:{" "}
-            <span class="text-error">{props.total - props.correct}</span>
-          </div>
-        </div>
-      </CardContent>
-    </Card>
+    <CommonSessionResult
+      answers={answers()}
+      sessionResult={props.sessionResult}
+    />
   );
 };

--- a/src/components/solid/Exercise/SessionResult.tsx
+++ b/src/components/solid/Exercise/SessionResult.tsx
@@ -55,7 +55,12 @@ export const SessionResult = (props: {
           grammarPointId: attempt.grammarPointId,
         };
       })
-      .filter((answer) => answer !== undefined) as {
+      .filter(
+        (answer) =>
+          answer !== undefined &&
+          answer.ru !== undefined &&
+          answer.en !== undefined,
+      ) as {
       ru: ExampleImpl;
       en: ExampleImpl;
       isCorrect: boolean;

--- a/src/components/solid/grammar-point/GrammarPoint.tsx
+++ b/src/components/solid/grammar-point/GrammarPoint.tsx
@@ -1,4 +1,7 @@
-import type { GrammarPoint as GrammarPointType } from "grammar-sdk";
+import type {
+  GrammarPoint as GrammarPointType,
+  Example as ExampleType,
+} from "grammar-sdk";
 import { For, Show } from "solid-js";
 import { Badge } from "ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "ui/card";
@@ -9,11 +12,12 @@ import { StartLesson } from "./StartLesson";
 import { Title } from "./Title";
 import { StructureDisplay } from "./StructureDisplay";
 
-type Props = Omit<GrammarPointType, "exercises"> & {
+type Props = GrammarPointType & {
   explanation?: string;
   next?: string;
   backTo?: string;
   inReview?: boolean;
+  examples: ExampleType[];
 };
 
 export const GrammarPoint = (props: Props) => {

--- a/src/features/grammar-point/GrammarPointForm.tsx
+++ b/src/features/grammar-point/GrammarPointForm.tsx
@@ -12,7 +12,7 @@ import { Select, SelectContainer, SelectLabel, SelectOption } from "ui/select";
 import type { JSX } from "solid-js/jsx-runtime";
 import { ExplanationDisplay } from "@components/solid/grammar-point/ExplanationDisplay";
 import { HtmlCheckbox } from "ui/html-checkbox";
-import type { Label } from "packages/grammar-sdk";
+import type { Label } from "grammar-sdk";
 import { Labels } from "./Labels";
 import { actions } from "astro:actions";
 

--- a/src/features/grammar-point/GrammarPointsTable.tsx
+++ b/src/features/grammar-point/GrammarPointsTable.tsx
@@ -5,7 +5,7 @@ import { cn } from "packages/ui/utils";
 import { actions } from "astro:actions";
 import { toast } from "solid-toast";
 import { SaveConfirmation } from "@components/common/SaveConfirmation";
-import type { GrammarPoint } from "packages/grammar-sdk";
+import type { GrammarPoint } from "grammar-sdk";
 import type { Label } from "grammar-sdk";
 import { Badge } from "packages/ui/badge";
 import { TextField, TextFieldInput } from "packages/ui/text-field";

--- a/src/features/grammar-point/Labels.tsx
+++ b/src/features/grammar-point/Labels.tsx
@@ -11,7 +11,7 @@ import {
 import { actions } from "astro:actions";
 import toast from "solid-toast";
 import { isServer } from "solid-js/web";
-import type { Label } from "packages/grammar-sdk";
+import type { Label } from "grammar-sdk";
 
 const LabelChip = (props: { children: string; color: string }) => {
   return (

--- a/src/features/grammar-point/type.ts
+++ b/src/features/grammar-point/type.ts
@@ -1,4 +1,4 @@
-import type { GrammarPoint, Label } from "packages/grammar-sdk";
+import type { GrammarPoint, Label } from "grammar-sdk";
 
 export type GrammarPointWithLabels = Omit<GrammarPoint, "labels"> & {
   labels: Label[];

--- a/src/pages/admin/grammar/[id]/index.astro
+++ b/src/pages/admin/grammar/[id]/index.astro
@@ -3,7 +3,10 @@ import { actions } from "astro:actions";
 import AdminLayout from "../../../../layouts/AdminLayout.astro";
 import { GrammarPointForm } from "~/features/grammar-point/GrammarPointForm";
 import { ExercisesForm } from "~/features/exercise/create/ExercisesForm";
-import { fetchGrammarPoint } from "packages/grammar-sdk";
+import {
+  fetchExercisesByGrammarPointId,
+  fetchGrammarPoint,
+} from "packages/grammar-sdk";
 import { contextFromAstro } from "~/libs/context";
 import Form from "@components/astro/form.astro";
 
@@ -14,6 +17,10 @@ if (!id || isNaN(Number(id))) {
 }
 
 const grammarPoint = await fetchGrammarPoint(id, contextFromAstro(Astro));
+const exercises = await fetchExercisesByGrammarPointId(
+  id,
+  contextFromAstro(Astro),
+);
 
 if (!grammarPoint) {
   return Astro.redirect("/admin/grammar");
@@ -46,14 +53,14 @@ const updateResult = Astro.getActionResult(actions.updateGrammarPoint);
   <div class="space-y-4 pt-5">
     <div>
       <h2 class="text-2xl font-semibold mb-4">
-        Exercises ({grammarPoint.exercises.length})
+        Exercises ({exercises.length})
       </h2>
       <p class="text-sm text-slate-500">
         All changes are not visible to users until you push "Save exercises".
       </p>
     </div>
     <ExercisesForm
-      defaultExercises={grammarPoint.exercises}
+      defaultExercises={exercises}
       grammarPointId={+grammarPoint.id}
       client:only="solid-js"
     />

--- a/src/pages/admin/grammar/[id]/index.astro
+++ b/src/pages/admin/grammar/[id]/index.astro
@@ -3,10 +3,7 @@ import { actions } from "astro:actions";
 import AdminLayout from "../../../../layouts/AdminLayout.astro";
 import { GrammarPointForm } from "~/features/grammar-point/GrammarPointForm";
 import { ExercisesForm } from "~/features/exercise/create/ExercisesForm";
-import {
-  fetchExercisesByGrammarPointId,
-  fetchGrammarPoint,
-} from "packages/grammar-sdk";
+import { fetchExercisesByGrammarPointId, fetchGrammarPoint } from "grammar-sdk";
 import { contextFromAstro } from "~/libs/context";
 import Form from "@components/astro/form.astro";
 

--- a/src/pages/admin/grammar/index.astro
+++ b/src/pages/admin/grammar/index.astro
@@ -5,9 +5,7 @@ import { GrammarPointsTable } from "~/features/grammar-point/GrammarPointsTable"
 import { fetchAllGrammarPoints, getLabels } from "grammar-sdk";
 import { contextFromAstro } from "~/libs/context";
 
-const grammarPointsList = await fetchAllGrammarPoints(contextFromAstro(Astro), {
-  exercises: false,
-});
+const grammarPointsList = await fetchAllGrammarPoints(contextFromAstro(Astro));
 const labels = await getLabels(contextFromAstro(Astro));
 
 if (labels.isErr()) {

--- a/src/pages/api/cache/index.astro
+++ b/src/pages/api/cache/index.astro
@@ -1,7 +1,7 @@
 ---
 import type { APIRoute } from "astro";
 import { contextFromAstro } from "~/libs/context";
-import { clearCache, Context } from "packages/grammar-sdk";
+import { clearCache, Context } from "grammar-sdk";
 import logger from "libs/logger";
 
 export const GET: APIRoute = async (_context) => {

--- a/src/pages/grammar/[id]/index.astro
+++ b/src/pages/grammar/[id]/index.astro
@@ -9,7 +9,7 @@ import { contextFromAstro } from "~/libs/context";
 import { getLiveEntry } from "astro:content";
 import { fetchExamplesByGrammarPointId } from "grammar-sdk";
 import logger from "libs/logger";
-import type { FullExample } from "grammar-sdk/src/example";
+import type { Example } from "grammar-sdk";
 
 const { id } = Astro.params;
 const backTo = Astro.url.searchParams.get("backTo") ?? undefined;
@@ -32,7 +32,7 @@ if (!grammarPointEntry) {
   return Astro.redirect("/grammar");
 }
 
-let examples: FullExample[] = [];
+let examples: Example[] = [];
 
 try {
   examples = await fetchExamplesByGrammarPointId(id, contextFromAstro(Astro));

--- a/src/pages/grammar/[id]/index.astro
+++ b/src/pages/grammar/[id]/index.astro
@@ -7,9 +7,9 @@ import { Anchor } from "ui/anchor";
 import Layout from "../../../layouts/Layout.astro";
 import { contextFromAstro } from "~/libs/context";
 import { getLiveEntry } from "astro:content";
-import { fetchExamplesByGrammarPointId } from "packages/grammar-sdk";
+import { fetchExamplesByGrammarPointId } from "grammar-sdk";
 import logger from "libs/logger";
-import type { FullExample } from "packages/grammar-sdk/src/example";
+import type { FullExample } from "grammar-sdk/src/example";
 
 const { id } = Astro.params;
 const backTo = Astro.url.searchParams.get("backTo") ?? undefined;

--- a/src/pages/grammar/[id]/index.astro
+++ b/src/pages/grammar/[id]/index.astro
@@ -7,6 +7,9 @@ import { Anchor } from "ui/anchor";
 import Layout from "../../../layouts/Layout.astro";
 import { contextFromAstro } from "~/libs/context";
 import { getLiveEntry } from "astro:content";
+import { fetchExamplesByGrammarPointId } from "packages/grammar-sdk";
+import logger from "libs/logger";
+import type { FullExample } from "packages/grammar-sdk/src/example";
 
 const { id } = Astro.params;
 const backTo = Astro.url.searchParams.get("backTo") ?? undefined;
@@ -29,6 +32,14 @@ if (!grammarPointEntry) {
   return Astro.redirect("/grammar");
 }
 
+let examples: FullExample[] = [];
+
+try {
+  examples = await fetchExamplesByGrammarPointId(id, contextFromAstro(Astro));
+} catch (error) {
+  logger.error(error);
+}
+
 const inReview = id
   ? ((
       (await (await fetchGpInReview(Astro)).json()) ?? ([] as string[])
@@ -47,6 +58,7 @@ const grammarPoint = grammarPointEntry.data;
           backTo={backTo}
           client:visible
           inReview={inReview}
+          examples={examples}
           {...grammarPoint}
         />
         <section class="flex flex-row gap-5 justify-center items-center mt-5">

--- a/src/pages/grammar/[id]/practice.astro
+++ b/src/pages/grammar/[id]/practice.astro
@@ -3,10 +3,7 @@ import { simpleShuffle } from "utils/array";
 import { Exercises } from "../../../components/solid/Exercise/Exercises";
 import Layout from "../../../layouts/Layout.astro";
 import { contextFromAstro } from "~/libs/context";
-import {
-  fetchExercisesByGrammarPointIds,
-  type Exercise,
-} from "packages/grammar-sdk";
+import { fetchExercisesByGrammarPointIds, type Exercise } from "grammar-sdk";
 
 const ids = Astro.params.id?.split("-") ?? [];
 

--- a/src/pages/grammar/[id]/practice.astro
+++ b/src/pages/grammar/[id]/practice.astro
@@ -19,7 +19,7 @@ try {
   return Astro.redirect("/error");
 }
 
-if (!rawExercises) {
+if (!rawExercises.length) {
   return Astro.redirect("/error");
 }
 

--- a/src/pages/grammar/[id]/practice.astro
+++ b/src/pages/grammar/[id]/practice.astro
@@ -3,25 +3,30 @@ import { simpleShuffle } from "utils/array";
 import { Exercises } from "../../../components/solid/Exercise/Exercises";
 import Layout from "../../../layouts/Layout.astro";
 import { contextFromAstro } from "~/libs/context";
-import { getLiveCollection } from "astro:content";
+import {
+  fetchExercisesByGrammarPointIds,
+  type Exercise,
+} from "packages/grammar-sdk";
 
 const ids = Astro.params.id?.split("-") ?? [];
 
-const { entries: grammarPoints, error } = await getLiveCollection(
-  "grammarPoints",
-  {
-    ids,
-    context: contextFromAstro(Astro),
-  },
-);
+let rawExercises: Exercise[];
 
-if (error) {
+try {
+  rawExercises = Object.values(
+    await fetchExercisesByGrammarPointIds(ids, contextFromAstro(Astro)),
+  )
+    .flat()
+    .filter((e) => !!e);
+} catch (error) {
   return Astro.redirect("/error");
 }
 
-const exercises = simpleShuffle(
-  (grammarPoints ?? []).flatMap((g) => g.data.exercises),
-);
+if (!rawExercises) {
+  return Astro.redirect("/error");
+}
+
+const exercises = simpleShuffle(rawExercises);
 ---
 
 <Layout title="Practice">

--- a/src/pages/grammar/practice/result.astro
+++ b/src/pages/grammar/practice/result.astro
@@ -1,5 +1,5 @@
 ---
-import { SessionResult } from "@components/solid/Exercise/SessionResult";
+import { LocalSessionResult } from "@components/solid/Exercise/LocalSessionResult";
 import Layout from "@layouts/Layout.astro";
 import { getLiveCollection } from "astro:content";
 import { contextFromAstro } from "~/libs/context";
@@ -14,9 +14,5 @@ if (error) {
 ---
 
 <Layout title="Practice results">
-  <SessionResult
-    client:only="solid-js"
-    sessionResult={undefined}
-    grammar={grammar?.map((entry) => entry.data) ?? []}
-  />
+  <LocalSessionResult client:only="solid-js" />
 </Layout>

--- a/src/pages/grammar/practice/result.astro
+++ b/src/pages/grammar/practice/result.astro
@@ -1,16 +1,6 @@
 ---
 import { LocalSessionResult } from "@components/solid/Exercise/LocalSessionResult";
 import Layout from "@layouts/Layout.astro";
-import { getLiveCollection } from "astro:content";
-import { contextFromAstro } from "~/libs/context";
-
-const { entries: grammar, error } = await getLiveCollection("grammarPoints", {
-  context: contextFromAstro(Astro),
-});
-
-if (error) {
-  return Astro.redirect("/error");
-}
 ---
 
 <Layout title="Practice results">

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -1,5 +1,5 @@
 import type { APIContext } from "astro";
-import { fetchAllGrammarPoints } from "packages/grammar-sdk";
+import { fetchAllGrammarPoints } from "grammar-sdk";
 import { contextFromAstro } from "~/libs/context";
 
 type SitemapUrl = {

--- a/src/pages/sr/lesson/index.astro
+++ b/src/pages/sr/lesson/index.astro
@@ -14,14 +14,14 @@ const lesson = await getLessons(1, Astro.locals.user).then(
   (lessons) => lessons[0],
 );
 
+if (!lesson) {
+  return Astro.redirect("/sr/congratulations");
+}
+
 const examples = await fetchExamplesByGrammarPointId(
   lesson.id,
   contextFromAstro(Astro),
 );
-
-if (!lesson) {
-  return Astro.redirect("/sr/congratulations");
-}
 ---
 
 <Layout title="Lessons">

--- a/src/pages/sr/lesson/index.astro
+++ b/src/pages/sr/lesson/index.astro
@@ -3,7 +3,7 @@ import { GrammarPoint } from "@components/solid/grammar-point/GrammarPoint";
 import Layout from "../../../layouts/Layout.astro";
 
 import { getLessons } from "space-repetition";
-import { fetchExamplesByGrammarPointId } from "packages/grammar-sdk";
+import { fetchExamplesByGrammarPointId } from "grammar-sdk";
 import { contextFromAstro } from "~/libs/context";
 
 if (!Astro.locals.user) {

--- a/src/pages/sr/lesson/index.astro
+++ b/src/pages/sr/lesson/index.astro
@@ -2,10 +2,23 @@
 import { GrammarPoint } from "@components/solid/grammar-point/GrammarPoint";
 import Layout from "../../../layouts/Layout.astro";
 
-import type { Lesson } from "space-repetition";
-import { GET as getLessons } from "../../api/sr/lesson";
+import { getLessons } from "space-repetition";
+import { fetchExamplesByGrammarPointId } from "packages/grammar-sdk";
+import { contextFromAstro } from "~/libs/context";
 
-const lesson = (await (await getLessons(Astro)).json())[0] as Lesson;
+if (!Astro.locals.user) {
+  return Astro.redirect("/");
+}
+
+const lesson = await getLessons(1, Astro.locals.user).then(
+  (lessons) => lessons[0],
+);
+
+const examples = await fetchExamplesByGrammarPointId(
+  lesson.id,
+  contextFromAstro(Astro),
+);
+
 if (!lesson) {
   return Astro.redirect("/sr/congratulations");
 }
@@ -14,7 +27,12 @@ if (!lesson) {
 <Layout title="Lessons">
   {
     lesson && (
-      <GrammarPoint client:visible {...lesson} next="/sr/lesson/start" />
+      <GrammarPoint
+        client:visible
+        {...lesson}
+        examples={examples}
+        next="/sr/lesson/start"
+      />
     )
   }
 </Layout>

--- a/src/pages/sr/review/[sessionId]/result.astro
+++ b/src/pages/sr/review/[sessionId]/result.astro
@@ -2,7 +2,7 @@
 import { SessionResult } from "@components/solid/Exercise/SessionResult";
 import Layout from "@layouts/Layout.astro";
 import { actions } from "astro:actions";
-import { fetchExercisesByGrammarPointIds } from "grammar-sdk/src/grammar";
+import { fetchExercisesByGrammarPointIds } from "grammar-sdk";
 import { contextFromAstro } from "~/libs/context";
 
 const sessionResult = Astro.params.sessionId

--- a/src/pages/sr/review/[sessionId]/result.astro
+++ b/src/pages/sr/review/[sessionId]/result.astro
@@ -2,7 +2,7 @@
 import { SessionResult } from "@components/solid/Exercise/SessionResult";
 import Layout from "@layouts/Layout.astro";
 import { actions } from "astro:actions";
-import { getLiveCollection } from "astro:content";
+import { fetchExercisesByGrammarPointIds } from "packages/grammar-sdk/src/grammar";
 import { contextFromAstro } from "~/libs/context";
 
 const sessionResult = Astro.params.sessionId
@@ -10,11 +10,20 @@ const sessionResult = Astro.params.sessionId
       sessionId: Astro.params.sessionId,
     })
   : undefined;
-const { entries: grammar, error } = await getLiveCollection("grammarPoints", {
-  context: contextFromAstro(Astro),
-});
 
-if (error) {
+const attemptsGpIds = Array.from(
+  new Set(
+    sessionResult?.data?.attempts.map((attempt) => attempt.grammarPointId),
+  ),
+);
+let exercises: Awaited<ReturnType<typeof fetchExercisesByGrammarPointIds>> = {};
+
+try {
+  exercises = await fetchExercisesByGrammarPointIds(
+    attemptsGpIds,
+    contextFromAstro(Astro),
+  );
+} catch {
   return Astro.redirect("/error");
 }
 ---
@@ -22,10 +31,7 @@ if (error) {
 <Layout title="Review results">
   {
     sessionResult?.data ? (
-      <SessionResult
-        sessionResult={sessionResult.data}
-        grammar={grammar?.map((entry) => entry.data) ?? []}
-      />
+      <SessionResult sessionResult={sessionResult.data} exercises={exercises} />
     ) : (
       <div>
         No session result found, probably it hasn't been calculated yet. Please

--- a/src/pages/sr/review/[sessionId]/result.astro
+++ b/src/pages/sr/review/[sessionId]/result.astro
@@ -2,7 +2,7 @@
 import { SessionResult } from "@components/solid/Exercise/SessionResult";
 import Layout from "@layouts/Layout.astro";
 import { actions } from "astro:actions";
-import { fetchExercisesByGrammarPointIds } from "packages/grammar-sdk/src/grammar";
+import { fetchExercisesByGrammarPointIds } from "grammar-sdk/src/grammar";
 import { contextFromAstro } from "~/libs/context";
 
 const sessionResult = Astro.params.sessionId

--- a/src/pages/sr/review/index.astro
+++ b/src/pages/sr/review/index.astro
@@ -1,11 +1,13 @@
 ---
 import { Exercises } from "@components/solid/Exercise/Exercises";
 import Layout from "@layouts/Layout.astro";
-import type { GrammarPointReview } from "space-repetition";
-import { GET as getReview } from "../../api/sr/review";
+import { getNextRound } from "space-repetition";
 
-// TODO: return exercise only
-const review = (await (await getReview(Astro)).json()) as GrammarPointReview[];
+if (!Astro.locals.user) {
+  return Astro.redirect("/");
+}
+
+const review = await getNextRound(Astro.locals.user);
 if (!review.length) return Astro.redirect("/sr/review/no-reviews");
 ---
 

--- a/src/pages/sr/review/index.astro
+++ b/src/pages/sr/review/index.astro
@@ -4,6 +4,7 @@ import Layout from "@layouts/Layout.astro";
 import type { GrammarPointReview } from "space-repetition";
 import { GET as getReview } from "../../api/sr/review";
 
+// TODO: return exercise only
 const review = (await (await getReview(Astro)).json()) as GrammarPointReview[];
 if (!review.length) return Astro.redirect("/sr/review/no-reviews");
 ---

--- a/src/services/practice.ts
+++ b/src/services/practice.ts
@@ -1,18 +1,18 @@
-import type { Attempt } from "space-repetition";
+import type { LocalAttempt } from "space-repetition";
 import { Session } from "space-repetition/session";
 
-const getAttemptsFromSessionStorage = (): Attempt[] => {
+const getAttemptsFromSessionStorage = (): LocalAttempt[] => {
   const maybeAttempts = globalThis?.sessionStorage?.getItem?.("practice");
   return maybeAttempts ? JSON.parse(maybeAttempts) : [];
 };
 
-export const saveAttemptToSessionStorage = (attempt: Attempt) => {
+export const saveAttemptToSessionStorage = (attempt: LocalAttempt) => {
   const oldAttempts = getAttemptsFromSessionStorage();
   sessionStorage.setItem("practice", JSON.stringify([...oldAttempts, attempt]));
 };
 
-export const getPracticeSessionResults = () => {
+export const getLocalSessionResults = () => {
   const attempts = getAttemptsFromSessionStorage();
-  const session = attempts.length ? Session(attempts) : undefined;
+  const session = attempts.length ? Session<"local">(attempts) : undefined;
   return session && Session.calculateResult(session);
 };

--- a/src/services/sr.ts
+++ b/src/services/sr.ts
@@ -2,6 +2,7 @@ import { actions } from "astro:actions";
 import toast from "solid-toast";
 import type { Attempt, Stage } from "space-repetition";
 import { saveAttemptToSessionStorage } from "./practice";
+import type { Exercise } from "packages/grammar-sdk";
 
 export const clearPracticeSession = () => {
   globalThis?.sessionStorage?.removeItem?.("practice");
@@ -9,6 +10,7 @@ export const clearPracticeSession = () => {
 
 export const saveAttempt = async (
   attempt: Attempt & { exerciseOrder: number },
+  exercise: Exercise,
 ) => {
   const { exerciseOrder, ...rest } = attempt;
   if (attempt.reviewSessionId === "practice") {
@@ -17,6 +19,7 @@ export const saveAttempt = async (
       // TODO: temporary workaround to fix session results, we should save exercise order in DB as well
       // since stage is not 1-1 map with exercise order anymore
       stage: exerciseOrder as Stage,
+      exercise: exercise,
     });
   }
   const result = await actions.saveAttempt(rest);

--- a/src/services/sr.ts
+++ b/src/services/sr.ts
@@ -2,7 +2,7 @@ import { actions } from "astro:actions";
 import toast from "solid-toast";
 import type { Attempt, Stage } from "space-repetition";
 import { saveAttemptToSessionStorage } from "./practice";
-import type { Exercise } from "packages/grammar-sdk";
+import type { Exercise } from "grammar-sdk";
 
 export const clearPracticeSession = () => {
   globalThis?.sessionStorage?.removeItem?.("practice");


### PR DESCRIPTION
reduce Supabase quota consumption

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Practice, lesson, and review pages now load and render exercises/examples directly from the SDK.
  * Grammar point viewing now fetches grammar-point data together with its examples.
  * Added a dedicated local practice results view; SR lesson/review flows now use exercise-based loading.
  * Admin grammar point editing now loads and displays associated exercises explicitly.

* **Bug Fixes**
  * Improved visibility handling for hidden items and more consistent filtering across screens.
  * Updated exercise persistence/lookup behavior for more accurate NOT_FOUND handling and exercise updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->