### PR TITLE
add admin note to gp

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "pnpm": ">=11"
   },
   "scripts": {
+    "dev": "pnpm run --filter=web dev",
     "setup-db": "pnpm run migrate && pnpm run seed",
     "reset-db": "supabase db reset && pnpm run setup-db",
     "test": "vitest run --exclude '**/tests/integration/**'",

--- a/packages/grammar-sdk/src/grammar-point/dto.ts
+++ b/packages/grammar-sdk/src/grammar-point/dto.ts
@@ -20,6 +20,7 @@ export const GrammarPointDb = {
       explanation: g.explanation ?? undefined,
       labels: g.labelsToGrammarPoints.map((l) => l.label.id),
       hide: g.hide,
+      note: g.note ?? undefined,
     };
   },
 };

--- a/packages/grammar-sdk/src/grammar-point/index.ts
+++ b/packages/grammar-sdk/src/grammar-point/index.ts
@@ -15,6 +15,7 @@ export interface GrammarPoint {
   structure?: string;
   explanation?: string;
   labels: number[];
+  note?: string;
 }
 
 export type CreateGrammarPoint = Omit<

--- a/packages/web/src/actions/gp-management.ts
+++ b/packages/web/src/actions/gp-management.ts
@@ -40,6 +40,7 @@ export const gpManagement = {
       structure: z.string().optional(),
       explanation: z.string().optional(),
       torfl: z.string().optional(),
+      note: z.string().optional(),
     }),
     handler: async (input, context) => {
       const result = await createGrammarPoint(input, contextFromAstro(context));
@@ -71,6 +72,7 @@ export const gpManagement = {
       englishTitle: z.string().optional(),
       torfl: z.string().optional(),
       hide: z.boolean(),
+      note: z.string().optional(),
     }),
     handler: async (input, context) => {
       const result = await updateGrammarPoint(

--- a/packages/web/src/features/grammar-point/GrammarPointForm.tsx
+++ b/packages/web/src/features/grammar-point/GrammarPointForm.tsx
@@ -28,6 +28,7 @@ interface GrammarPointFormProps {
     explanation?: string;
     hide?: boolean;
     labels: number[];
+    note?: string;
   };
   labels?: Label[];
   success?: boolean;
@@ -199,6 +200,16 @@ export const GrammarPointForm = (props: GrammarPointFormProps) => {
             <ExplanationDisplay text={explanation()} />
           </Preview>
         </div>
+        <div>
+          <TextField value={props.initialData?.note}>
+            <TextFieldLabel for="note">Admin Note</TextFieldLabel>
+            <TextFieldTextArea id="note" name="note" rows="4">
+              {props.initialData?.note}
+            </TextFieldTextArea>
+          </TextField>
+          <p class="mt-1 text-slate-500 text-xs">Visible to admin only</p>
+        </div>
+
         <div>{resolved()}</div>
         <div class="flex gap-3 pt-4">
           <Button type="submit" disabled={props.isLoading}>

--- a/packages/web/src/pages/admin/grammar/[id]/index.astro
+++ b/packages/web/src/pages/admin/grammar/[id]/index.astro
@@ -43,6 +43,7 @@ const updateResult = Astro.getActionResult(actions.updateGrammarPoint);
         explanation: grammarPoint.explanation ?? undefined,
         hide: grammarPoint.hide ?? false,
         labels: grammarPoint.labels,
+        note: grammarPoint.note ?? undefined,
       }}
     />
   </Form>


### PR DESCRIPTION
- **add note to grammar point edit**
- **add dev script for web filtering**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional notes field for grammar points.
  - Administrators can add and edit grammar-point notes through the management form.
  - Existing notes are displayed when editing grammar points.
- **Bug Fixes**
  - Grammar-point notes are now correctly preserved when loaded from stored data.
- **Chores**
  - Added a development command for running the web workspace locally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->